### PR TITLE
On mac, hid_enumerate can crash if the device is unplugged during enumeration.

### DIFF
--- a/mac/hid.c
+++ b/mac/hid.c
@@ -320,6 +320,9 @@ struct hid_device_info  HID_API_EXPORT *hid_enumerate(unsigned short vendor_id, 
 
 		IOHIDDeviceRef dev = device_array[i];
 
+        if (!dev) {
+            continue;
+        }
 		dev_vid = get_vendor_id(dev);
 		dev_pid = get_product_id(dev);
 


### PR DESCRIPTION
This can happen easily if you ask the system to be notified when the device is unplugged and then enumerate to see what is left.
