### PR TITLE
Added a hid_exit function do do cleanup some before exiting

### DIFF
--- a/hidapi/hidapi.h
+++ b/hidapi/hidapi.h
@@ -77,6 +77,17 @@ extern "C" {
 		};
 
 
+		/** @brief Deinitialize hidapi
+
+			Deinitialize libusb.
+
+			This function should be called after closing all open devices
+			and before your application terminates.
+
+			@ingroup API
+		*/
+		void HID_API_EXPORT HID_API_CALL hid_exit();
+
 		/** @brief Enumerate the HID Devices.
 
 			This function returns a linked list of all the HID devices

--- a/hidtest/hidtest.cpp
+++ b/hidtest/hidtest.cpp
@@ -69,6 +69,7 @@ int main(int argc, char* argv[])
 	handle = hid_open(0x4d8, 0x3f, NULL);
 	if (!handle) {
 		printf("unable to open device\n");
+		hid_exit();
  		return 1;
 	}
 
@@ -181,6 +182,9 @@ int main(int argc, char* argv[])
 #ifdef WIN32
 	system("pause");
 #endif
+
+	hid_close(handle);
+	hid_exit();
 
 	return 0;
 }

--- a/linux/hid-libusb.c
+++ b/linux/hid-libusb.c
@@ -378,6 +378,14 @@ static char *make_path(libusb_device *dev, int interface_number)
 	return strdup(str);
 }
 
+void HID_API_EXPORT hid_exit()
+{
+	if (initialized) {
+		libusb_exit(NULL);
+		initialized = 0;
+	}
+}
+
 struct hid_device_info  HID_API_EXPORT *hid_enumerate(unsigned short vendor_id, unsigned short product_id)
 {
 	libusb_device **devs;

--- a/linux/hid.c
+++ b/linux/hid.c
@@ -193,6 +193,10 @@ end:
 	return ret;
 }
 
+void HID_API_EXPORT hid_exit()
+{
+	// Nothing to do (As far as i know)
+}
 
 struct hid_device_info  HID_API_EXPORT *hid_enumerate(unsigned short vendor_id, unsigned short product_id)
 {

--- a/mac/hid.c
+++ b/mac/hid.c
@@ -288,6 +288,10 @@ static void init_hid_manager(void)
 	IOHIDManagerOpen(hid_mgr, kIOHIDOptionsTypeNone);
 }
 
+void HID_API_EXPORT hid_exit()
+{
+	// TODO: Implement hid cleanup
+}
 
 struct hid_device_info  HID_API_EXPORT *hid_enumerate(unsigned short vendor_id, unsigned short product_id)
 {

--- a/windows/hid.cpp
+++ b/windows/hid.cpp
@@ -184,6 +184,13 @@ static void lookup_functions()
 }
 #endif
 
+
+void HID_API_EXPORT hid_exit()
+{
+	// TODO: Keep an handle on hid.dll
+	//       and call FreeLibrary(lib);
+}
+
 struct hid_device_info HID_API_EXPORT * HID_API_CALL hid_enumerate(unsigned short vendor_id, unsigned short product_id)
 {
 	BOOL res;


### PR DESCRIPTION
- Close device in hidtest.cpp
- Call hid_exit() at the end
- TODO: MacOS and Windows use a blank hid_exit

Signed-off-by: Camille Moncelier moncelier@devlife.org
