### PR TITLE
parse interface number out of the path on Windows where possible

### DIFF
--- a/windows/hid.cpp
+++ b/windows/hid.cpp
@@ -367,8 +367,20 @@ struct hid_device_info HID_API_EXPORT * HID_API_CALL hid_enumerate(unsigned shor
 			/* Release Number */
 			cur_dev->release_number = attrib.VersionNumber;
 
-			/* Interface Number (Unsupported on Windows)*/
+			/* Interface Number (Unsupported on Windows directly but might be able to parse out of path)*/
 			cur_dev->interface_number = -1;
+			if (cur_dev->path) {
+				char * interfaceComponent = strstr(cur_dev->path, "&mi_");
+				if (interfaceComponent) {
+					char * hexPtr = interfaceComponent + 4;
+					char * orig = hexPtr;
+					cur_dev->interface_number = strtoul(hexPtr, &hexPtr, 16);
+					if (hexPtr == orig) {
+						/* couldn't parse out a hex num - set back to -1 */
+						cur_dev->interface_number = -1;
+					}
+				}
+			}
 		}
 
 cont_close:


### PR DESCRIPTION
Although the Windows API doesn't provide direct access to interface number, on child devices representing the interfaces of a composite device, it is parsable from the device path. An excerpt of a path for interface 1 of a Razer Hydra device is as follows:
\?\hid#vid_1532&pid_0300&mi_01

(see table 4 and related text here http://msdn.microsoft.com/en-us/windows/hardware/gg487473)

This patch, if a path is available, and further, if &mi_ is found, parses what it can for an unsigned hex value into the interface_number field. If there is any problem, the dummy -1 value is restored.
