### PR TITLE
Changing the sharing mode of the Windows HID device opens to be shared re

### DIFF
--- a/windows/hid.cpp
+++ b/windows/hid.cpp
@@ -270,7 +270,7 @@ struct hid_device_info HID_API_EXPORT * HID_API_CALL hid_enumerate(unsigned shor
 		// Open a handle to the device
 		write_handle = CreateFileA(device_interface_detail_data->DevicePath,
 			GENERIC_WRITE |GENERIC_READ,
-			0x0, /*share mode*/
+			FILE_SHARE_READ | FILE_SHARE_WRITE, //0x0, /*share mode*/
 			NULL,
 			OPEN_EXISTING,
 			FILE_FLAG_OVERLAPPED,//FILE_ATTRIBUTE_NORMAL,
@@ -458,7 +458,7 @@ HID_API_EXPORT hid_device * HID_API_CALL hid_open_path(const char *path)
 	// Open a handle to the device
 	dev->device_handle = CreateFileA(path,
 			GENERIC_WRITE |GENERIC_READ,
-			0x0, /*share mode*/
+			FILE_SHARE_READ | FILE_SHARE_WRITE, //0x0, /*share mode*/
 			NULL,
 			OPEN_EXISTING,
 			FILE_FLAG_OVERLAPPED,//FILE_ATTRIBUTE_NORMAL,


### PR DESCRIPTION
Changing the sharing mode of the Windows HID device opens to be shared read and write.  This is required to make the code work in VRPN for opening the X-keys devices.

(Commit from russell-taylor's fork for VRPN - unfortunately not forked through the github interface so it doesn't show up in the network view. https://github.com/russell-taylor/hidapi Rebased onto the latest master.)
