### PR TITLE
Use lowercase version of windows winioctl header

### DIFF
--- a/windows/hid.cpp
+++ b/windows/hid.cpp
@@ -36,7 +36,7 @@
 
 extern "C" {
 	#include <setupapi.h>
-	#include "WinIoCTL.h"
+	#include <winioctl.h>
 	#ifdef HIDAPI_USE_DDK
 		#include <hidsdi.h>
 	#endif


### PR DESCRIPTION
Use lowercase version of windows winioctl header to support mingw build on case-sensitive systems, such as Ubuntu 10.04 x64 with the mingw tools installed.
