### PR TITLE
Reduce hidapi CPU usage

### DIFF
--- a/linux/hid-libusb.c
+++ b/linux/hid-libusb.c
@@ -682,7 +682,7 @@ static void *read_thread(void *param)
 		struct timeval tv;
 
 		tv.tv_sec = 0;
-		tv.tv_usec = 100; //TODO: Fix this value.
+		tv.tv_usec = 100000; //TODO: Fix this value.
 		res = libusb_handle_events_timeout(NULL, &tv);
 		if (res < 0) {
 			/* There was an error. Break out of this loop. */


### PR DESCRIPTION
Hi,

I have found my hidapi application to be using much more CPU time than what I would have expected.  The reason is the very short timeout that is used when polling for hid events in the device handler thread.  I have changed that timeout from 100us to 100ms.  This slows down closing potentially, but has no other negative effects as far as I can tell.

Thanks for hidlib!  It works great in all other respects!
Hans
