### PR TITLE
Ntstatus

### DIFF
--- a/windows/hid.cpp
+++ b/windows/hid.cpp
@@ -22,6 +22,10 @@
 
 #include <windows.h>
 
+#ifndef _NTDEF_
+typedef LONG NTSTATUS;
+#endif
+
 #ifdef __MINGW32__
 #include <ntdef.h>
 #include <winbase.h>


### PR DESCRIPTION
On some systems, it seems like the NTSTATUS type is not defined. (Info from VRPN on Visual Studio 2005, have not tested it personally).  This change adds the typedef guarded by an appropriate ifdef that won't re-define the type if it's been defined already, such as in Visual Studio 2008. @russelltaylor may be able to provide more information.
