### PR TITLE
Fill in the USB interface number on Linux with hidraw

### DIFF
--- a/linux/hid.c
+++ b/linux/hid.c
@@ -322,8 +322,16 @@ struct hid_device_info  HID_API_EXPORT *hid_enumerate(unsigned short vendor_id, 
 			str = udev_device_get_sysattr_value(dev, "bcdDevice");
 			cur_dev->release_number = (str)? strtol(str, NULL, 16): 0x0;
 			
-			/* Interface Number (Unsupported on Linux/hidraw) */
+			/* Interface Number */
 			cur_dev->interface_number = -1;
+			dev = udev_device_get_parent_with_subsystem_devtype(
+				   hid_dev,
+				   "usb",
+				   "usb_interface");
+			if (dev) {
+				str = udev_device_get_sysattr_value(dev, "bInterfaceNumber");
+				cur_dev->interface_number = (str)? strtol(str, NULL, 16): -1;
+			}
 
 		}
 		else


### PR DESCRIPTION
Note that this reuses the dev variable, which should be fine since it's done after all other uses of it, and the udev_device_get_parent_with_subsystem_devtype() function used to grab it is documented as returning a value that doesn't need to be unref()d.
