### PR TITLE
Fix output report length bug & hid read on Windows

### DIFF
--- a/windows/hid.c
+++ b/windows/hid.c
@@ -125,6 +125,7 @@ extern "C" {
 struct hid_device_ {
 		HANDLE device_handle;
 		BOOL blocking;
+		USHORT output_report_length;
 		size_t input_report_length;
 		void *last_error_str;
 		DWORD last_error_num;
@@ -138,6 +139,7 @@ static hid_device *new_hid_device()
 	hid_device *dev = (hid_device*) calloc(1, sizeof(hid_device));
 	dev->device_handle = INVALID_HANDLE_VALUE;
 	dev->blocking = TRUE;
+	dev->output_report_length = 0;
 	dev->input_report_length = 0;
 	dev->last_error_str = NULL;
 	dev->last_error_num = 0;
@@ -553,6 +555,7 @@ HID_API_EXPORT hid_device * HID_API_CALL hid_open_path(const char *path)
 		register_error(dev, "HidP_GetCaps");	
 		goto err_pp_data;
 	}
+	dev->output_report_length = caps.OutputReportByteLength;
 	dev->input_report_length = caps.InputReportByteLength;
 	HidD_FreePreparsedData(pp_data);
 
@@ -574,14 +577,27 @@ int HID_API_EXPORT HID_API_CALL hid_write(hid_device *dev, const unsigned char *
 	BOOL res;
 
 	OVERLAPPED ol;
+	unsigned char *buf;
 	memset(&ol, 0, sizeof(ol));
 
-	res = WriteFile(dev->device_handle, data, length, NULL, &ol);
+	if (length >= dev->output_report_length) {
+		buf = data;
+	} else {
+		buf = (unsigned char *)malloc(dev->output_report_length);
+		memcpy(buf, data, length);
+		memset(buf + length, 0, dev->output_report_length - length);
+		length = dev->output_report_length;
+	}
+
+	res = WriteFile(dev->device_handle, buf, length, NULL, &ol);
 	
 	if (!res) {
 		if (GetLastError() != ERROR_IO_PENDING) {
 			// WriteFile() failed. Return error.
 			register_error(dev, "WriteFile");
+
+			if (buf != data)
+				free(buf);
 			return -1;
 		}
 	}
@@ -592,8 +608,14 @@ int HID_API_EXPORT HID_API_CALL hid_write(hid_device *dev, const unsigned char *
 	if (!res) {
 		// The Write operation failed.
 		register_error(dev, "WriteFile");
+
+		if (buf != data)
+			free(buf);
 		return -1;
 	}
+	
+	if (buf != data)
+		free(buf);
 
 	return bytes_written;
 }
@@ -610,6 +632,7 @@ int HID_API_EXPORT HID_API_CALL hid_read_timeout(hid_device *dev, unsigned char 
 	if (!dev->read_pending) {
 		// Start an Overlapped I/O read.
 		dev->read_pending = TRUE;
+		memset(dev->read_buf, 0, dev->input_report_length);
 		ResetEvent(ev);
 		res = ReadFile(dev->device_handle, dev->read_buf, dev->input_report_length, &bytes_read, &dev->ol);
 		
@@ -648,12 +671,15 @@ int HID_API_EXPORT HID_API_CALL hid_read_timeout(hid_device *dev, unsigned char 
 			   number (0x0) on the beginning of the report anyway. To make this
 			   work like the other platforms, and to make it work more like the
 			   HID spec, we'll skip over this byte. */
+			size_t copy_len;
 			bytes_read--;
-			memcpy(data, dev->read_buf+1, length);
+			copy_len = length > bytes_read ? bytes_read : length;
+			memcpy(data, dev->read_buf+1, copy_len);
 		}
 		else {
 			/* Copy the whole buffer, report number and all. */
-			memcpy(data, dev->read_buf, length);
+			size_t copy_len = length > bytes_read ? bytes_read : length;
+			memcpy(data, dev->read_buf, copy_len);
 		}
 	}
 	


### PR DESCRIPTION
On Windows, data shorter than the output report length must be padded to the output report length of the device.  This copies data shorter than this length into a temporary buffer.  Longer reports behave as before (not sure if it needs to be a multiple of the output report length or what - should be so left it alone).

Also, fix the hid read to never copy in more than was read from the hid device.
