### PR TITLE
Fix hidapi enumeration bug on OSX

### DIFF
--- a/mac/hid.c
+++ b/mac/hid.c
@@ -404,6 +404,13 @@ int HID_API_EXPORT hid_exit(void)
 	return 0;
 }
 
+static void process_pending_events() {
+	SInt32 res;
+	do {
+		res = CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0.001, FALSE);
+	} while(res != kCFRunLoopRunFinished && res != kCFRunLoopRunTimedOut);
+}
+
 struct hid_device_info  HID_API_EXPORT *hid_enumerate(unsigned short vendor_id, unsigned short product_id)
 {
 	struct hid_device_info *root = NULL; // return object
@@ -416,6 +423,9 @@ struct hid_device_info  HID_API_EXPORT *hid_enumerate(unsigned short vendor_id, 
 	/* Set up the HID Manager if it hasn't been done */
 	hid_init();
 	
+	/* give the IOHIDManager a chance to update itself */
+	process_pending_events();
+
 	/* Get a list of the Devices */
 	CFSetRef device_set = IOHIDManagerCopyDevices(hid_mgr);
 
@@ -701,6 +711,9 @@ hid_device * HID_API_EXPORT hid_open_path(const char *path)
 
 	/* Set up the HID Manager if it hasn't been done */
 	hid_init();
+
+	/* give the IOHIDManager a chance to update itself */
+	process_pending_events();
 
 	CFSetRef device_set = IOHIDManagerCopyDevices(hid_mgr);
 	


### PR DESCRIPTION
Surrounding application may not be using a run loop (or may not have
given it a chance to run).  Process any outstanding events (this does
imply that hid_enumerate will take about at least 1ms to process).
