### PR TITLE
Mac: Use IOKit paths

### DIFF
--- a/mac/hid.c
+++ b/mac/hid.c
@@ -214,11 +214,6 @@ static unsigned short get_product_id(IOHIDDeviceRef device)
 	return get_int_property(device, CFSTR(kIOHIDProductIDKey));
 }
 
-static int32_t get_location_id(IOHIDDeviceRef device)
-{
-	return get_int_property(device, CFSTR(kIOHIDLocationIDKey));
-}
-
 static int32_t get_max_report_length(IOHIDDeviceRef device)
 {
 	return get_int_property(device, CFSTR(kIOHIDMaxInputReportSizeKey));
@@ -1047,6 +1042,11 @@ HID_API_EXPORT const wchar_t * HID_API_CALL  hid_error(hid_device *dev)
 
 
 #if 0
+static int32_t get_location_id(IOHIDDeviceRef device)
+{
+	return get_int_property(device, CFSTR(kIOHIDLocationIDKey));
+}
+
 static int32_t get_usage(IOHIDDeviceRef device)
 {
 	int32_t res;

--- a/mac/hid.c
+++ b/mac/hid.c
@@ -266,46 +266,6 @@ static int get_string_property(IOHIDDeviceRef device, CFStringRef prop, wchar_t 
 
 }
 
-static int get_string_property_utf8(IOHIDDeviceRef device, CFStringRef prop, char *buf, size_t len)
-{
-	CFStringRef str;
-	if (!len)
-		return 0;
-
-	str = IOHIDDeviceGetProperty(device, prop);
-
-	buf[0] = 0;
-
-	if (str) {
-		len--;
-
-		CFIndex str_len = CFStringGetLength(str);
-		CFRange range;
-		range.location = 0;
-		range.length = str_len;
-		CFIndex used_buf_len;
-		CFIndex chars_copied;
-		chars_copied = CFStringGetBytes(str,
-			range,
-			kCFStringEncodingUTF8,
-			(char)'?',
-			FALSE,
-			(UInt8*)buf,
-			len,
-			&used_buf_len);
-
-		if (used_buf_len == len)
-			buf[len] = 0; /* len is decremented above */
-		else
-			buf[used_buf_len] = 0;
-
-		return used_buf_len;
-	}
-	else
-		return 0;
-}
-
-
 static int get_serial_number(IOHIDDeviceRef device, wchar_t *buf, size_t len)
 {
 	return get_string_property(device, CFSTR(kIOHIDSerialNumberKey), buf, len);


### PR DESCRIPTION
These commits change hid_enumerate() and hid_open_path() to use IOKit IOService:/ paths for devices.

On 10.6 and above, it's real clean and much simpler than the previous hid_open_path() implementation.

On 10.5, it's a little sticky since IOHIDDeviceGetService() isn't available. First, I'm weakly linking to IOHIDDeviceGetService(), so its availability gets checked at runtime and used if it exists (10.6 and up). For 10.5, the backup plan is to just get the io_service_t directly out of the IOHIDDevice struct. The IOHIDDevice struct never changed throughout 10.5, and I've tested (with hidtest) successfully on 10.5.8 ppc, i386, and x86_64. It's naughty, but it works :)

Also, the device_list removal patches are needed for disconnect detection to work right. I guess since the IOHIDDevice is being created without going through the manager, assigning the removal callback to the manager wouldn't work (the callback wasn't getting called).
