### PR TITLE
Removed includes that causes MinGW builds to fail.

### DIFF
--- a/windows/hid.c
+++ b/windows/hid.c
@@ -26,11 +26,6 @@
 typedef LONG NTSTATUS;
 #endif
 
-#ifdef __MINGW32__
-#include <ntdef.h>
-#include <winbase.h>
-#endif
-
 #ifdef __CYGWIN__
 #include <ntdef.h>
 #define _wcsdup wcsdup


### PR DESCRIPTION
The statement
# include <windows.h>

in windows\hid.c includes "winnt.h".

The statement
# include <ntdef.h>

in windows\hid.c causes a redefinition of a structure defined in "winnt.h", when compiling with mingw 32 and 64 bit.
