### PR TITLE
setlocale

### DIFF
--- a/linux/hid-libusb.c
+++ b/linux/hid-libusb.c
@@ -409,17 +409,22 @@ struct hid_device_info  HID_API_EXPORT *hid_enumerate(unsigned short vendor_id, 
 	libusb_device_handle *handle;
 	ssize_t num_devs;
 	int i = 0;
-	
+
 	struct hid_device_info *root = NULL; // return object
 	struct hid_device_info *cur_dev = NULL;
-	
+	char locale[64];
+	char *tmp = setlocale(LC_ALL, NULL);
+	strncpy(locale, tmp, 64);
+
 	setlocale(LC_ALL,"");
-	
+
 	hid_init();
 
 	num_devs = libusb_get_device_list(usb_context, &devs);
-	if (num_devs < 0)
+	if (num_devs < 0) {
+		setlocale(LC_ALL, locale);
 		return NULL;
+	}
 	while ((dev = devs[i++]) != NULL) {
 		struct libusb_device_descriptor desc;
 		struct libusb_config_descriptor *conf_desc = NULL;
@@ -429,7 +434,7 @@ struct hid_device_info  HID_API_EXPORT *hid_enumerate(unsigned short vendor_id, 
 		int res = libusb_get_device_descriptor(dev, &desc);
 		unsigned short dev_vid = desc.idVendor;
 		unsigned short dev_pid = desc.idProduct;
-		
+
 		/* HID's are defined at the interface level. */
 		if (desc.bDeviceClass != LIBUSB_CLASS_PER_INTERFACE)
 			continue;
@@ -560,6 +565,7 @@ struct hid_device_info  HID_API_EXPORT *hid_enumerate(unsigned short vendor_id, 
 	}
 
 	libusb_free_device_list(devs, 1);
+	setlocale(LC_ALL, locale);
 
 	return root;
 }

--- a/linux/hid.c
+++ b/linux/hid.c
@@ -163,13 +163,17 @@ static int get_device_string(hid_device *dev, const char *key, wchar_t *string, 
 	struct udev_device *udev_dev, *parent;
 	struct stat s;
 	int ret = -1;
-	
+	char locale[64];
+	char *tmp = setlocale(LC_ALL, NULL);
+	strncpy(locale, tmp, 64);
+
 	setlocale(LC_ALL,"");
 
 	/* Create the udev object */
 	udev = udev_new();
 	if (!udev) {
 		printf("Can't create udev\n");
+		setlocale(LC_ALL, locale);
 		return -1;
 	}
 
@@ -199,6 +203,7 @@ end:
 	// parent doesn't need to be (and can't be) unref'd.
 	// I'm not sure why, but it'll throw double-free() errors.
 	udev_unref(udev);
+	setlocale(LC_ALL, locale);
 
 	return ret;
 }

--- a/mac/hid.c
+++ b/mac/hid.c
@@ -441,13 +441,18 @@ struct hid_device_info  HID_API_EXPORT *hid_enumerate(unsigned short vendor_id, 
 	struct hid_device_info *cur_dev = NULL;
 	CFIndex num_devices;
 	int i;
-	
+	char locale[64];
+	char *tmp = setlocale(LC_ALL, NULL);
+	strncpy(locale, tmp, 64);
+
 	setlocale(LC_ALL,"");
 
 	/* Set up the HID Manager if it hasn't been done */
-	if (hid_init() < 0)
+	if (hid_init() < 0) {
+		setlocale(LC_ALL, locale);
 		return NULL;
-	
+	}
+
 	/* give the IOHIDManager a chance to update itself */
 	process_pending_events();
 
@@ -521,10 +526,11 @@ struct hid_device_info  HID_API_EXPORT *hid_enumerate(unsigned short vendor_id, 
 			cur_dev->interface_number = -1;
 		}
 	}
-	
+
 	free(device_array);
 	CFRelease(device_set);
-	
+	setlocale(LC_ALL, locale);
+
 	return root;
 }
 


### PR DESCRIPTION
This is a quick fix for a setlocale bug affecting my application.
Using setlocale to force use of the default locale for USB enumeration changes the current locale of the application. This simple fix restores the locale to the previous locale instead of the default one.

Signed-off-by: Gilles Grégoire gilles.gregoire@gmail.com
