### PR TITLE
Build a shared library on Linux (libhidapi.so)

### DIFF
--- a/linux/.gitignore
+++ b/linux/.gitignore
@@ -10,4 +10,5 @@ Release
 *.dll
 *.pdb
 *.o
+*.so
 hidtest

--- a/linux/Makefile
+++ b/linux/Makefile
@@ -8,6 +8,8 @@
 
 all: hidtest
 
+libs: libhidapi-libusb.so libhidapi-hidraw.so
+
 CC       ?= gcc
 CFLAGS   ?= -Wall -g
 
@@ -17,12 +19,20 @@ CXXFLAGS ?= -Wall -g
 COBJS     = hid-libusb.o
 CPPOBJS   = ../hidtest/hidtest.o
 OBJS      = $(COBJS) $(CPPOBJS)
-LIBS      = `pkg-config libusb-1.0 libudev --libs`
+LIBS_USB  = `pkg-config libusb-1.0 --libs`
+LIBS_UDEV = `pkg-config libudev --libs`
+LIBS      = $(LIBS_USB) $(LIBS_UDEV)
 INCLUDES ?= -I../hidapi `pkg-config libusb-1.0 --cflags`
 
 
 hidtest: $(OBJS)
 	$(CXX) $(CXXFLAGS) $(LDFLAGS) $^ $(LIBS) -o hidtest
+
+libhidapi-libusb.so: ../hidapi/hidapi.h hid-libusb.c
+	$(CC) $(CFLAGS) $(INCLUDES) $(LDFLAGS) $(LIBS_USB) -shared -fpic -Wl,-soname,$@.0 $^ -o $@
+
+libhidapi-hidraw.so: ../hidapi/hidapi.h hid.c
+	$(CC) $(CFLAGS) -I../hidapi $(LDFLAGS) $(LIBS_UDEV) -shared -fpic -Wl,-soname,$@.0 $^ -o $@
 
 $(COBJS): %.o: %.c
 	$(CC) $(CFLAGS) -c $(INCLUDES) $< -o $@
@@ -31,6 +41,6 @@ $(CPPOBJS): %.o: %.cpp
 	$(CXX) $(CXXFLAGS) -c $(INCLUDES) $< -o $@
 
 clean:
-	rm -f $(OBJS) hidtest
+	rm -f $(OBJS) hidtest libhidapi-libusb.so libhidapi-hidraw.so
 
-.PHONY: clean
+.PHONY: clean libs


### PR DESCRIPTION
It would make things easier both for the users of hidapi (like me) and for distro packagers (who often aren't allowed to bundle a library like this with the program that uses it) if the Linux version of hidapi built a shared library, like the Windows version does.

So, these commits add a target to the Makefile that builds such a shared library (libhidapi.so).

To cater for the two different implementations on Linux, this reuses the variable that the Makefile already uses to decide which of them is used with hidtest, to decide which is built into the library.
