### PR TITLE
Fixed a typo that made the Linux shared libraries be empty.

### DIFF
--- a/linux/.gitignore
+++ b/linux/.gitignore
@@ -11,4 +11,5 @@ Release
 *.pdb
 *.o
 *.so
-hidtest
+hidtest-hidraw
+hidtest-libusb

--- a/linux/Makefile
+++ b/linux/Makefile
@@ -37,10 +37,10 @@ hidtest-libusb: $(COBJS_LIBUSB) $(CPPOBJS)
 	$(CXX) $(LDFLAGS) $^ $(LIBS_USB) -o $@
 
 # Shared Libs
-libhidapi-libusb.so: $(OBJS_LIBUSB)
+libhidapi-libusb.so: $(COBJS_LIBUSB)
 	$(CC) $(LDFLAGS) $(LIBS_USB) -shared -fpic -Wl,-soname,$@.0 $^ -o $@
 
-libhidapi-hidraw.so: $(OBJS_HIDRAW)
+libhidapi-hidraw.so: $(COBJS_HIDRAW)
 	$(CC) $(LDFLAGS) $(LIBS_UDEV) -shared -fpic -Wl,-soname,$@.0 $^ -o $@
 
 # Objects


### PR DESCRIPTION
I would have put this on the old pull request (#46), but I apparently don't have permission to comment on that anymore, nor to reopen it.

In short, the libraries don't currently work because they are empty, because of a typo: the dependencies for the .so files should use COBJS_* instead of OBJS_*

This commit fixes that, and also adds the new hidtest-\* binaries to the list of files ignored by git.
