### PR TITLE
Fix pid/vid getting in hid_enumerate() for Bluetooth devices

### DIFF
--- a/linux/hid.c
+++ b/linux/hid.c
@@ -289,7 +289,7 @@ static int get_device_string(hid_device *dev, enum device_string_id key, wchar_t
 						ret = (ret == (size_t)-1)? -1: 0;
 						break;
 					case DEVICE_STRING_SERIAL:
-						mbstowcs(string, serial_number_utf8, maxlen);
+						ret = mbstowcs(string, serial_number_utf8, maxlen);
 						ret = (ret == (size_t)-1)? -1: 0;
 						break;
 					default:
@@ -317,7 +317,8 @@ static int get_device_string(hid_device *dev, enum device_string_id key, wchar_t
 					str = udev_device_get_sysattr_value(parent, key_str);
 					if (str) {
 						/* Convert the string from UTF-8 to wchar_t */
-						ret = (mbstowcs(string, str, maxlen) < 0)? -1: 0;
+						ret = mbstowcs(string, str, maxlen);
+						ret = (ret == (size_t)-1)? -1: 0;
 						goto end;
 					}
 				}


### PR DESCRIPTION
Searching for the USB host and extracting the vendor ID and product
ID from there only works for USB-based HID devices. In the case of
HID devices connected via Bluetooth, we would get the VID/PID of the
Bluetooth host adapter (if it's a USB device).

To work around this, we don't use the USB VID/PID, but extract the
information directly from the sysfs path - this will return the right
VID/PID for Bluetooth devices and USB devices.

Tested on Linux 3.2.0 for both USB and Bluetooth devices.
