### PR TITLE
Mac: make_path() values changes from process to process

### DIFF
--- a/linux/hid.c
+++ b/linux/hid.c
@@ -9,7 +9,7 @@
  Linux Version - 6/2/2009
 
  Copyright 2009, All Rights Reserved.
-
+ 
  At the discretion of the user of this library,
  this software may be licensed under the terms of the
  GNU Public License v3, a BSD-Style license, or the
@@ -121,12 +121,12 @@ static wchar_t *copy_udev_string(struct udev_device *dev, const char *udev_name)
 }
 
 /* uses_numbered_reports() returns 1 if report_descriptor describes a device
-   which contains numbered reports. */
+   which contains numbered reports. */ 
 static int uses_numbered_reports(__u8 *report_descriptor, __u32 size) {
 	int i = 0;
 	int size_code;
 	int data_len, key_size;
-
+	
 	while (i < size) {
 		int key = report_descriptor[i];
 
@@ -136,9 +136,9 @@ static int uses_numbered_reports(__u8 *report_descriptor, __u32 size) {
 			   numbered reports. */
 			return 1;
 		}
-
+		
 		//printf("key: %02hhx\n", key);
-
+		
 		if ((key & 0xf0) == 0xf0) {
 			/* This is a Long Item. The next byte contains the
 			   length of the data section (value) for this key.
@@ -173,11 +173,11 @@ static int uses_numbered_reports(__u8 *report_descriptor, __u32 size) {
 			};
 			key_size = 1;
 		}
-
+		
 		/* Skip over this key and it's associated data */
 		i += data_len + key_size;
 	}
-
+	
 	/* Didn't find a Report ID key. Device doesn't use numbered reports. */
 	return 0;
 }
@@ -246,8 +246,6 @@ static int get_device_string(hid_device *dev, enum device_string_id key, wchar_t
 	struct udev_device *udev_dev, *parent, *hid_dev;
 	struct stat s;
 	int ret = -1;
-        char *serial_number_utf8 = NULL;
-        char *product_name_utf8 = NULL;
 
 	/* Create the udev object */
 	udev = udev_new();
@@ -268,6 +266,8 @@ static int get_device_string(hid_device *dev, enum device_string_id key, wchar_t
 		if (hid_dev) {
 			unsigned short dev_vid;
 			unsigned short dev_pid;
+			char *serial_number_utf8 = NULL;
+			char *product_name_utf8 = NULL;
 			int bus_type;
 
 			ret = parse_uevent_info(
@@ -323,13 +323,13 @@ static int get_device_string(hid_device *dev, enum device_string_id key, wchar_t
 					}
 				}
 			}
+
+			free(serial_number_utf8);
+			free(product_name_utf8);
 		}
 	}
 
 end:
-        free(serial_number_utf8);
-        free(product_name_utf8);
-
 	udev_device_unref(udev_dev);
 	// parent and hid_dev don't need to be (and can't be) unref'd.
 	// I'm not sure why, but they'll throw double-free() errors.
@@ -362,7 +362,7 @@ struct hid_device_info  HID_API_EXPORT *hid_enumerate(unsigned short vendor_id, 
 	struct udev *udev;
 	struct udev_enumerate *enumerate;
 	struct udev_list_entry *devices, *dev_list_entry;
-
+	
 	struct hid_device_info *root = NULL; // return object
 	struct hid_device_info *cur_dev = NULL;
 	struct hid_device_info *prev_dev = NULL; // previous device
@@ -541,7 +541,7 @@ struct hid_device_info  HID_API_EXPORT *hid_enumerate(unsigned short vendor_id, 
 	/* Free the enumerator and udev objects. */
 	udev_enumerate_unref(enumerate);
 	udev_unref(udev);
-
+	
 	return root;
 }
 
@@ -564,7 +564,7 @@ hid_device * hid_open(unsigned short vendor_id, unsigned short product_id, const
 	struct hid_device_info *devs, *cur_dev;
 	const char *path_to_open = NULL;
 	hid_device *handle = NULL;
-
+	
 	devs = hid_enumerate(vendor_id, product_id);
 	cur_dev = devs;
 	while (cur_dev) {
@@ -590,7 +590,7 @@ hid_device * hid_open(unsigned short vendor_id, unsigned short product_id, const
 	}
 
 	hid_free_enumeration(devs);
-
+	
 	return handle;
 }
 
@@ -646,7 +646,7 @@ hid_device * HID_API_EXPORT hid_open_path(const char *path)
 				uses_numbered_reports(rpt_desc.value,
 				                      rpt_desc.size);
 		}
-
+		
 		return dev;
 	}
 	else {
@@ -688,9 +688,9 @@ int HID_API_EXPORT hid_read_timeout(hid_device *dev, unsigned char *data, size_t
 	}
 
 	bytes_read = read(dev->device_handle, data, length);
-	if (bytes_read < 0 && (errno == EAGAIN || errno == EINPROGRESS))
+	if (bytes_read < 0 && errno == EAGAIN)
 		bytes_read = 0;
-
+	
 	if (bytes_read >= 0 &&
 	    kernel_version < KERNEL_VERSION(2,6,34) &&
 	    dev->uses_numbered_reports) {


### PR DESCRIPTION
In the Mac implementation of make_path(), the last part of the string is the memory location of the device:

```
res = snprintf(buf, len, "%s_%04hx_%04hx_%p",
                   transport, vid, pid, device);
```

The problem is that this pointer only remains the same for that process and does not provide a common name for different processes to access the same device.

This is an issue because all my USB HID devices don't use the serial number field.  There is no other way to identify the device other than its physical location.

It would seem to make more sense to me to use the Location ID for the last part of the string.
