### PR TITLE
OS X: Fixed byte/wchar_t buffer size problem 

### DIFF
--- a/mac/hid.c
+++ b/mac/hid.c
@@ -1050,17 +1050,17 @@ void HID_API_EXPORT hid_close(hid_device *dev)
 
 int HID_API_EXPORT_CALL hid_get_manufacturer_string(hid_device *dev, wchar_t *string, size_t maxlen)
 {
-	return get_manufacturer_string(dev->device_handle, string, maxlen);
+	return get_manufacturer_string(dev->device_handle, string, sizeof(wchar_t) * maxlen);
 }
 
 int HID_API_EXPORT_CALL hid_get_product_string(hid_device *dev, wchar_t *string, size_t maxlen)
 {
-	return get_product_string(dev->device_handle, string, maxlen);
+	return get_product_string(dev->device_handle, string, sizeof(wchar_t) * maxlen);
 }
 
 int HID_API_EXPORT_CALL hid_get_serial_number_string(hid_device *dev, wchar_t *string, size_t maxlen)
 {
-	return get_serial_number(dev->device_handle, string, maxlen);
+	return get_serial_number(dev->device_handle, string, sizeof(wchar_t) * maxlen);
 }
 
 int HID_API_EXPORT_CALL hid_get_indexed_string(hid_device *dev, int string_index, wchar_t *string, size_t maxlen)


### PR DESCRIPTION
The API doc states hid_get_*_string uses a buffer size in multiples of wchar_t, but this is not the case as the implementation currently stands, on OS X.

This commit converts the wchar_t buffer size to byte buffer size where necessary.

See also issue #69:
