### PR TITLE
Compiler warnings on Linux and OS X

### DIFF
--- a/linux/hid.c
+++ b/linux/hid.c
@@ -90,10 +90,13 @@ hid_device *new_hid_device()
 	return dev;
 }
 
+#if 0
+//TODO: Implement this function
 static void register_error(hid_device *device, const char *op)
 {
 
 }
+#endif
 
 /* The caller must free the returned string with free(). */
 static wchar_t *utf8_to_wchar_t(const char *utf8)

--- a/mac/hid.c
+++ b/mac/hid.c
@@ -390,8 +390,6 @@ static int make_path(IOHIDDeviceRef device, char *buf, size_t len)
 /* Initialize the IOHIDManager. Return 0 for success and -1 for failure. */
 static int init_hid_manager(void)
 {
-	IOReturn res;
-	
 	/* Initialize all the HID Manager Objects */
 	hid_mgr = IOHIDManagerCreate(kCFAllocatorDefault, kIOHIDOptionsTypeNone);
 	if (hid_mgr) {


### PR DESCRIPTION
This patch fixes the following compiler warnings:
- <b>mac/hid.c</b>: Remove unused <code>IOReturn res;</code> in <code>init_hid_manager()</code>
- <b>linux/hid.c</b>: <code>#if 0</code> the definition of <code>register_error()</code> (fixes issue #68)
