### PR TITLE
Fix ERROR_INVALID_USER_BUFFER for long buffers.

### DIFF
--- a/windows/hid.c
+++ b/windows/hid.c
@@ -610,8 +610,8 @@ int HID_API_EXPORT HID_API_CALL hid_write(hid_device *dev, const unsigned char *
 		buf = (unsigned char *) malloc(dev->output_report_length);
 		memcpy(buf, data, length);
 		memset(buf + length, 0, dev->output_report_length - length);
-		length = dev->output_report_length;
 	}
+	length = dev->output_report_length;
 
 	res = WriteFile(dev->device_handle, buf, length, NULL, &ol);
 	


### PR DESCRIPTION
If you pass a buffer to hid_write() where `length` is strictly greater than `dev->output_report_length`, then `WriteFile` will fail with `ERROR_INVALID_USER_BUFFER`.

This fixes that problem. Tested on Windows 7 64-bit.
