### PR TITLE
Better kernel version detection.

### DIFF
--- a/linux/hid.c
+++ b/linux/hid.c
@@ -77,8 +77,25 @@ struct hid_device_ {
 	int uses_numbered_reports;
 };
 
-
 static __u32 kernel_version = 0;
+
+static __u32 detect_kernel_version(void)
+{
+	struct utsname name;
+	int major, minor, release;
+	int ret;
+	uname(&name);
+	ret = sscanf(name.release, "%d.%d.%d", &major, &minor, &release);
+	if (ret == 3) {
+		return KERNEL_VERSION(major, minor, release);
+	}
+	ret = sscanf(name.release, "%d.%d", &major, &minor);
+	if (ret == 2) {
+		return KERNEL_VERSION(major, minor, 0);
+	}
+	printf("Couldn't determine kernel version from version string \"%s\"\n", name.release);
+	return 0;
+}
 
 static hid_device *new_hid_device(void)
 {
@@ -345,6 +362,9 @@ int HID_API_EXPORT hid_init(void)
 	if (!locale)
 		setlocale(LC_CTYPE, "");
 
+	kernel_version = detect_kernel_version();
+	//printf("Kernel Version: %d\n", kernel_version);
+
 	return 0;
 }
 
@@ -600,21 +620,6 @@ hid_device * HID_API_EXPORT hid_open_path(const char *path)
 
 	dev = new_hid_device();
 
-	if (kernel_version == 0) {
-		struct utsname name;
-		int major, minor, release;
-		int ret;
-		uname(&name);
-		ret = sscanf(name.release, "%d.%d.%d", &major, &minor, &release);
-		if (ret == 3) {
-			kernel_version = major << 16 | minor << 8 | release;
-			//printf("Kernel Version: %d\n", kernel_version);
-		}
-		else {
-			printf("Couldn't sscanf() version string %s\n", name.release);
-		}
-	}
-
 	/* OPEN HERE */
 	dev->device_handle = open(path, O_RDWR);
 
@@ -700,6 +705,7 @@ int HID_API_EXPORT hid_read_timeout(hid_device *dev, unsigned char *data, size_t
 		bytes_read = 0;
 
 	if (bytes_read >= 0 &&
+	    kernel_version != 0 &&
 	    kernel_version < KERNEL_VERSION(2,6,34) &&
 	    dev->uses_numbered_reports) {
 		/* Work around a kernel bug. Chop off the first byte. */


### PR DESCRIPTION
This originally turned up on Debian unstable, using the linux-image-3.8-trunk-amd64 package.

$ uname -a
Linux pavillion 3.8-trunk-amd64 #1 SMP Debian 3.8.5-1~experimental.1 x86_64 GNU/Linux

When run with this kernel, hidapi prints "Couldn't sscanf() version string", which is somewhat reasonable.  But then in hid_read_timeout(), kernel_version is 0, which triggers the workaround for Linux 2.6.34, and leads to corrupt packets.

This patch does three things:

1) Successfully parses version numbers with only %d.%d and not %.d.%d.%d.
2) Tracks unrecognized kernel versions as a distinct value (KERNEL_VERSION_UNKNOWN).
3) Uses the workaround for 2.6.34 only if the kernel was positively identified.
