### PR TITLE
build: add config.* to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,9 +3,7 @@
 Makefile.in
 aclocal.m4
 autom4te.cache/
-config.guess
-config.h.in
-config.sub
+config.*
 configure
 depcomp
 install-sh
@@ -18,8 +16,5 @@ testgui/Makefile.in
 windows/Makefile.in
 
 Makefile
-config.h
-config.log
-config.status
 stamp-h1
 libtool


### PR DESCRIPTION
This makes HIDAPI less noisy when used a git submodule.

Signed-off-by: Spencer Oliver spen@spen-soft.co.uk
