### PR TITLE
Fix license

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 HIDAPI can be used under one of three licenses.
 
-1. The GNU Public License, version 3.0, in LICENSE-gpl3.txt
+1. The GNU General Public License, version 3.0, in LICENSE-gpl3.txt
 2. A BSD-Style License, in LICENSE-bsd.txt.
 3. The more liberal original HIDAPI license. LICENSE-orig.txt
 

--- a/hidapi/hidapi.h
+++ b/hidapi/hidapi.h
@@ -11,7 +11,7 @@
 
  At the discretion of the user of this library,
  this software may be licensed under the terms of the
- GNU Public License v3, a BSD-Style license, or the
+ GNU General Public License v3, a BSD-Style license, or the
  original HIDAPI license as outlined in the LICENSE.txt,
  LICENSE-gpl3.txt, LICENSE-bsd.txt, and LICENSE-orig.txt
  files located at the root of the source distribution.

--- a/libusb/hid.c
+++ b/libusb/hid.c
@@ -14,7 +14,7 @@
 
  At the discretion of the user of this library,
  this software may be licensed under the terms of the
- GNU Public License v3, a BSD-Style license, or the
+ GNU General Public License v3, a BSD-Style license, or the
  original HIDAPI license as outlined in the LICENSE.txt,
  LICENSE-gpl3.txt, LICENSE-bsd.txt, and LICENSE-orig.txt
  files located at the root of the source distribution.

--- a/linux/hid.c
+++ b/linux/hid.c
@@ -12,7 +12,7 @@
 
  At the discretion of the user of this library,
  this software may be licensed under the terms of the
- GNU Public License v3, a BSD-Style license, or the
+ GNU General Public License v3, a BSD-Style license, or the
  original HIDAPI license as outlined in the LICENSE.txt,
  LICENSE-gpl3.txt, LICENSE-bsd.txt, and LICENSE-orig.txt
  files located at the root of the source distribution.

--- a/mac/hid.c
+++ b/mac/hid.c
@@ -11,7 +11,7 @@
 
  At the discretion of the user of this library,
  this software may be licensed under the terms of the
- GNU Public License v3, a BSD-Style license, or the
+ GNU General Public License v3, a BSD-Style license, or the
  original HIDAPI license as outlined in the LICENSE.txt,
  LICENSE-gpl3.txt, LICENSE-bsd.txt, and LICENSE-orig.txt
  files located at the root of the source distribution.

--- a/windows/hid.c
+++ b/windows/hid.c
@@ -11,7 +11,7 @@
  
  At the discretion of the user of this library,
  this software may be licensed under the terms of the
- GNU Public License v3, a BSD-Style license, or the
+ GNU General Public License v3, a BSD-Style license, or the
  original HIDAPI license as outlined in the LICENSE.txt,
  LICENSE-gpl3.txt, LICENSE-bsd.txt, and LICENSE-orig.txt
  files located at the root of the source distribution.


### PR DESCRIPTION
"GNU Public License" does not exist. It is called "GNU General Public License", "GNU GPL" or simply "GPL".
