### PR TITLE
libusb/hid_open: Fix null pointer dereference

### DIFF
--- a/libusb/hid.c
+++ b/libusb/hid.c
@@ -619,7 +619,8 @@ hid_device * hid_open(unsigned short vendor_id, unsigned short product_id, const
 		if (cur_dev->vendor_id == vendor_id &&
 		    cur_dev->product_id == product_id) {
 			if (serial_number) {
-				if (wcscmp(serial_number, cur_dev->serial_number) == 0) {
+				if (cur_dev->serial_number &&
+				    wcscmp(serial_number, cur_dev->serial_number) == 0) {
 					path_to_open = cur_dev->path;
 					break;
 				}


### PR DESCRIPTION
When libusb can't open a device for any reason (e.g. file system permissions), hid_device_info.serial_number is NULL. Calling wcscmp(3) with NULL leads to a NULL pointer dereference, crashing the program.
