### PR TITLE
Added the missing return

### DIFF
--- a/mac/hid.c
+++ b/mac/hid.c
@@ -930,7 +930,11 @@ ret:
 
 int HID_API_EXPORT hid_read(hid_device *dev, unsigned char *data, size_t length)
 {
-	return hid_read_timeout(dev, data, length, (dev->blocking)? -1: 0);
+	if(dev) {
+		return hid_read_timeout(dev, data, length, (dev->blocking)? -1: 0);
+	} else {
+		return -1;
+	}
 }
 
 int HID_API_EXPORT hid_set_nonblocking(hid_device *dev, int nonblock)


### PR DESCRIPTION
When working with many devices will some time produce a null "dev" object.
