### PR TITLE
Remove "All Rights Reserved"

### DIFF
--- a/hidtest/hidtest.cpp
+++ b/hidtest/hidtest.cpp
@@ -6,7 +6,7 @@
 
  8/22/2009
 
- Copyright 2009, All Rights Reserved.
+ Copyright 2009
  
  This contents of this file may be used by anyone
  for any reason without any conditions and may be


### PR DESCRIPTION
The paragraph following "All Rights Reserved" says that the file may be used without any condition, so in fact no right is reserved. Furthermore the phrase in general is obsolete since the year 2000: https://en.wikipedia.org/wiki/All_rights_reserved
