### PR TITLE
libusb: remove the timeouts in hid_write()

### DIFF
--- a/libusb/hid.c
+++ b/libusb/hid.c
@@ -1021,7 +1021,7 @@ int HID_API_EXPORT hid_write(hid_device *dev, const unsigned char *data, size_t 
 			(2/*HID output*/ << 8) | report_number,
 			dev->interface,
 			(unsigned char *)data, length,
-			1000/*timeout millis*/);
+			0/*timeout millis*/);
 
 		if (res < 0)
 			return -1;
@@ -1038,7 +1038,7 @@ int HID_API_EXPORT hid_write(hid_device *dev, const unsigned char *data, size_t 
 			dev->output_endpoint,
 			(unsigned char*)data,
 			length,
-			&actual_length, 1000);
+			&actual_length, 0);
 
 		if (res < 0)
 			return -1;

--- a/linux/hid.c
+++ b/linux/hid.c
@@ -667,9 +667,15 @@ int HID_API_EXPORT hid_write(hid_device *dev, const unsigned char *data, size_t 
 {
 	int bytes_written;
 
-	bytes_written = write(dev->device_handle, data, length);
+	while (1) {
+		bytes_written = write(dev->device_handle, data, length);
+		if (bytes_written < 0 &&
+			(errno == ETIMEDOUT || errno == EINTR)) {
+			continue;
+		}
 
-	return bytes_written;
+		return bytes_written;
+	}
 }
 
 


### PR DESCRIPTION
The libusb/hid.c:hid_write() has timeouts in its calls to libusb_interrupt_transfer and libusb_control_transfer().  This timeout can sometimes be tripped (e.g., if the underlying hardware is slow), and no sensible error code is returned -- you just get a -1.  Hence, the caller can't know that it could just try again because the only error that occurred was a timeout (or that the message may have actually gotten through).

Additionally, the other hid.c:hid_write() implementations -- linux, mac, and windows -- are all blocking and do not timeout.  This makes the behavior of the libusb hid_write() different than the others, which seems weird.

This commit simply sets the libusb timeouts to 0 (i.e., infinite) to make the libusb hid_write() behave like the others.
