### PR TITLE
libusb: ignore string descs with index 0

### DIFF
--- a/libusb/hid.c
+++ b/libusb/hid.c
@@ -1267,16 +1267,25 @@ void HID_API_EXPORT hid_close(hid_device *dev)
 
 int HID_API_EXPORT_CALL hid_get_manufacturer_string(hid_device *dev, wchar_t *string, size_t maxlen)
 {
+	if (dev->manufacturer_index == 0) {
+		return -1;
+	}
 	return hid_get_indexed_string(dev, dev->manufacturer_index, string, maxlen);
 }
 
 int HID_API_EXPORT_CALL hid_get_product_string(hid_device *dev, wchar_t *string, size_t maxlen)
 {
+	if (dev->product_index == 0) {
+		return -1;
+	}
 	return hid_get_indexed_string(dev, dev->product_index, string, maxlen);
 }
 
 int HID_API_EXPORT_CALL hid_get_serial_number_string(hid_device *dev, wchar_t *string, size_t maxlen)
 {
+	if (dev->serial_index == 0) {
+		return -1;
+	}
 	return hid_get_indexed_string(dev, dev->serial_index, string, maxlen);
 }
 


### PR DESCRIPTION
When using the hid_get_{manufacturer,product,serial_number}_string functions, a device that has iManufacturer, iProduct or iSerialNumber equal to 0 would populate the buffer with the language ids in string descriptor 0. This patch makes the the functions return -1 instead. This seems to behave the same as the hidraw backend. String descriptor 0 can still be obtained via calling hid_get_indexed_string directly.
