### PR TITLE
hidapi: Add new hid_enumerate_device function.

### DIFF
--- a/hidapi/hidapi.h
+++ b/hidapi/hidapi.h
@@ -131,6 +131,21 @@ extern "C" {
 		*/
 		struct hid_device_info HID_API_EXPORT * HID_API_CALL hid_enumerate(unsigned short vendor_id, unsigned short product_id);
 
+		/** @brief Enumerate a HID Device.
+
+			This function returns the device information of a single device.
+
+			@ingroup API
+		    @param path The path name of the device to open
+
+		    @returns
+		    	This function returns a pointer to a linked list of type
+		    	struct #hid_device, containing information about the HID device
+		    	attached to the system, or NULL in the case of failure. Free
+		    	this linked list by calling hid_free_enumeration().
+		*/
+		struct hid_device_info HID_API_EXPORT * HID_API_CALL hid_enumerate_device(const char *path);
+
 		/** @brief Free an enumeration Linked List
 
 		    This function frees a linked list created by hid_enumerate().

--- a/libusb/hid.c
+++ b/libusb/hid.c
@@ -679,6 +679,12 @@ struct hid_device_info  HID_API_EXPORT *hid_enumerate(unsigned short vendor_id, 
 	return root;
 }
 
+struct hid_device_info HID_API_EXPORT * HID_API_CALL hid_enumerate_device(const char *path)
+{
+	/* TODO: Implement this function for platforms other than Windows. */
+	return NULL;
+}
+
 void  HID_API_EXPORT hid_free_enumeration(struct hid_device_info *devs)
 {
 	struct hid_device_info *d = devs;

--- a/linux/hid.c
+++ b/linux/hid.c
@@ -566,6 +566,12 @@ struct hid_device_info  HID_API_EXPORT *hid_enumerate(unsigned short vendor_id, 
 	return root;
 }
 
+struct hid_device_info HID_API_EXPORT * HID_API_CALL hid_enumerate_device(const char *path)
+{
+	/* TODO: Implement this function for platforms other than Windows. */
+	return NULL;
+}
+
 void  HID_API_EXPORT hid_free_enumeration(struct hid_device_info *devs)
 {
 	struct hid_device_info *d = devs;

--- a/mac/hid.c
+++ b/mac/hid.c
@@ -497,6 +497,12 @@ struct hid_device_info  HID_API_EXPORT *hid_enumerate(unsigned short vendor_id, 
 	return root;
 }
 
+struct hid_device_info HID_API_EXPORT * HID_API_CALL hid_enumerate_device(const char *path)
+{
+	/* TODO: Implement this function for platforms other than Windows. */
+	return NULL;
+}
+
 void  HID_API_EXPORT hid_free_enumeration(struct hid_device_info *devs)
 {
 	/* This function is identical to the Linux version. Platform independent. */


### PR DESCRIPTION
This function allows us to get information about a device when we already have its path. In the future this function may enumerate all interfaces on a device.

I will provide Linux and Mac implementations if you agree that this function is useful and should be added.

My current use case for this function is retrieving device paths from a WM_DEVICECHANGE event and then using this new function to query information about the HID device.