### PR TITLE
mac: fix behaviour of hid_get_feature_report

### DIFF
--- a/mac/hid.c
+++ b/mac/hid.c
@@ -948,7 +948,7 @@ int HID_API_EXPORT hid_send_feature_report(hid_device *dev, const unsigned char 
 
 int HID_API_EXPORT hid_get_feature_report(hid_device *dev, unsigned char *data, size_t length)
 {
-	CFIndex len = length;
+	CFIndex len = length - 1;
 	IOReturn res;
 
 	/* Return if the device has been unplugged. */
@@ -958,9 +958,9 @@ int HID_API_EXPORT hid_get_feature_report(hid_device *dev, unsigned char *data, 
 	res = IOHIDDeviceGetReport(dev->device_handle,
 	                           kIOHIDReportTypeFeature,
 	                           data[0], /* Report ID */
-	                           data, &len);
+	                           data + 1, &len);
 	if (res == kIOReturnSuccess)
-		return len;
+		return len + 1;
 	else
 		return -1;
 }


### PR DESCRIPTION
This fix is quite important for the Mac platform, since the behaviour of hid_get_feature_report was not following the specs. 
