### PR TITLE
Linux/hidraw: Ensure udev has initialized device before hid_enumerate returns it

### DIFF
--- a/linux/hid.c
+++ b/linux/hid.c
@@ -425,6 +425,12 @@ struct hid_device_info  HID_API_EXPORT *hid_enumerate(unsigned short vendor_id, 
 		raw_dev = udev_device_new_from_syspath(udev, sysfs_path);
 		dev_path = udev_device_get_devnode(raw_dev);
 
+		if (udev_device_get_is_initialized(raw_dev) != 1) {
+			/* udev has not initialized the device yet (which includes
+			   setting permissions on the device node) */
+			goto next;
+		}
+
 		hid_dev = udev_device_get_parent_with_subsystem_devtype(
 			raw_dev,
 			"hid",


### PR DESCRIPTION
In hid_enumerate(), skip any devices which have not yet been initialized by udev (which includes setting permissions on the device node).
Previously, a race condition was possible where hid_enumerate() could return a device that hid_open() could not open, because udev had not set permissions on the device node yet.

This resolves issue 217, "Occasional 'permission denied' when opening device" (https://github.com/signal11/hidapi/issues/217)
