### PR TITLE
Do not set timeout on libusb_transfer

### DIFF
--- a/libusb/hid.c
+++ b/libusb/hid.c
@@ -812,7 +812,7 @@ static void *read_thread(void *param)
 		length,
 		read_callback,
 		dev,
-		5000/*timeout*/);
+		0 /*timeout*/);
 
 	/* Make the first submission. Further submissions are made
 	   from inside read_callback() */


### PR DESCRIPTION
If the USB packet arrives after libusb_transfer times out but
before a new libusb_transfer is submitted, the packet will be
dropped by libusb. See libusb/io.c:handle_events()

This fixes the intermittent dropping packets in hidapi