### PR TITLE
hidtest: take vendor, product id, and serial as arguments

### DIFF
--- a/hidtest/hidtest.cpp
+++ b/hidtest/hidtest.cpp
@@ -42,7 +42,28 @@ int main(int argc, char* argv[])
 #endif
 
 	struct hid_device_info *devs, *cur_dev;
-	
+	unsigned short vendor_id = 0x4d8;
+	unsigned short product_id = 0x3f;
+	wchar_t *serial_number = NULL;
+
+	if (argc < 3 || argc > 4) {
+		printf("Arguments: VID PID <SERIAL>\n");
+		return -1;
+	} else {
+		res = sscanf(argv[1], "%hx", &vendor_id);
+		if (res != 1) {
+			printf("%s is not a valid vendor id, please use 0xXXX format\n", argv[1]);
+			return -1;
+		}
+		res = sscanf(argv[2], "%hx", &product_id);
+		if (res != 1) {
+			printf("%s is not a valid product id, please use 0xXXX format\n", argv[2]);
+			return -1;
+		}
+		if (argc == 4)
+			serial_number = (wchar_t *) argv[3];
+	}
+
 	if (hid_init())
 		return -1;
 
@@ -68,8 +89,7 @@ int main(int argc, char* argv[])
 
 	// Open the device using the VID, PID,
 	// and optionally the Serial number.
-	////handle = hid_open(0x4d8, 0x3f, L"12345");
-	handle = hid_open(0x4d8, 0x3f, NULL);
+	handle = hid_open(vendor_id, product_id, serial_number);
 	if (!handle) {
 		printf("unable to open device\n");
  		return 1;

--- a/hidtest/hidtest.cpp
+++ b/hidtest/hidtest.cpp
@@ -36,20 +36,12 @@ int main(int argc, char* argv[])
 	hid_device *handle;
 	int i;
 
-#ifdef WIN32
-	UNREFERENCED_PARAMETER(argc);
-	UNREFERENCED_PARAMETER(argv);
-#endif
-
 	struct hid_device_info *devs, *cur_dev;
 	unsigned short vendor_id = 0x4d8;
 	unsigned short product_id = 0x3f;
 	wchar_t *serial_number = NULL;
 
-	if (argc < 3 || argc > 4) {
-		printf("Arguments: VID PID <SERIAL>\n");
-		return -1;
-	} else {
+	if (argc > 2 && argc <= 4) {
 		res = sscanf(argv[1], "%hx", &vendor_id);
 		if (res != 1) {
 			printf("%s is not a valid vendor id, please use 0xXXX format\n", argv[1]);
@@ -62,6 +54,11 @@ int main(int argc, char* argv[])
 		}
 		if (argc == 4)
 			serial_number = (wchar_t *) argv[3];
+
+		printf("Using custom VENDOR/PRODUCT values--some tests may not work\n");
+	} else if (argc == 2 || argc > 4) {
+		printf("Invalid argument. Pass no arguments to use defaults or [VENDOR PRODUCT [SERIAL]]\n");
+		return -1;
 	}
 
 	if (hid_init())


### PR DESCRIPTION
This change makes the test app a bit more quickly useful for any HID device. I tested this with a USB keyboard.

I'm not sure if the serial_number matters, it didn't seem to in my testing, but it seems best to try to grab it from the args as well.