### PR TITLE
fixed calling convention (unresolved external symbol linker errors)

### DIFF
--- a/hidapi/hidapi.h
+++ b/hidapi/hidapi.h
@@ -31,7 +31,7 @@
 
 #ifdef _WIN32
       #define HID_API_EXPORT __declspec(dllexport)
-      #define HID_API_CALL
+      #define HID_API_CALL __cdecl
 #else
       #define HID_API_EXPORT /**< API export macro */
       #define HID_API_CALL /**< API call macro */


### PR DESCRIPTION
If user is building own solution with calling convention (eg. __fastcall) other than default given by visual studio, linker throws "unresolved external symbol" errors.

hidtest.exe is working fine as it is using same default calling convention as hid.dll 