### PR TITLE
[Buildsystem] Add autogen.sh script

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -e
+srcdir="$(dirname $0)"
+cd "$srcdir"
+if [ -z ${LIBTOOLIZE} ] && GLIBTOOLIZE="`which glibtoolize 2>/dev/null`"; then
+  LIBTOOLIZE="${GLIBTOOLIZE}"
+  export LIBTOOLIZE
+fi
+autoreconf --install --force --warnings=all


### PR DESCRIPTION
Nowadays it's quite common to have a `./autogen.sh` script instead calling `autoreconf` manually. Also helps for unifying depends build systems.