### PR TITLE
windows: Fix MSYS2 support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -107,7 +107,7 @@ case $host in
 	AC_CHECK_LIB([usb], [libusb_init], [LIBS_LIBUSB_PRIVATE="${LIBS_LIBUSB_PRIVATE} -lusb"], [hidapi_lib_error libusb])
 	echo libs_priv: $LIBS_LIBUSB_PRIVATE
 	;;
-*-mingw*)
+*-mingw* | *msys*)
 	AC_MSG_RESULT([ (Windows back-end, using MinGW)])
 	backend="windows"
 	os="windows"


### PR DESCRIPTION
Builds work with MinGW-w64, but not with MSYS2 - this patch fixes that.