### PR TITLE
windows: Avoid null pointer dereference in hid_error.

### DIFF
--- a/windows/hid.c
+++ b/windows/hid.c
@@ -864,6 +864,9 @@ int HID_API_EXPORT_CALL HID_API_CALL hid_get_indexed_string(hid_device *dev, int
 
 HID_API_EXPORT const wchar_t * HID_API_CALL  hid_error(hid_device *dev)
 {
+	if (!dev) {
+		return NULL;
+	}
 	return (wchar_t*)dev->last_error_str;
 }
 


### PR DESCRIPTION
It's not entirely clear that `hid_error` is only for once you have a device open. In any case, the added resilience of a null pointer check in an error path is probably well worth the small amount of code.