### PR TITLE
windows: Fix build issue noticed with MSVC 2008 Express.

### DIFF
--- a/windows/hid.c
+++ b/windows/hid.c
@@ -172,7 +172,12 @@ static void register_error(hid_device *device, const char *op)
 		NULL,
 		GetLastError(),
 		MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+#ifdef _MSC_VER
+		(LPWSTR)&msg, 0/*sz*/,
+#else
+		/* mingw gcc -pedantic warning fix? */
 		(LPVOID)&msg, 0/*sz*/,
+#endif
 		NULL);
 	
 	/* Get rid of the CR and LF that FormatMessage() sticks at the


### PR DESCRIPTION
Introduced by an apparent warning fix in b5b15d0, so the change is behind a compiler ifdef. Noticed when updating VRPN to use latest upstream master HIDAPI, our visual studio project CI build broke with

```
z:\j\workspace\vrpn-windows-vcproj\submodules/hidapi/windows/hid.c(176): error C2664: 'FormatMessageW' : cannot convert parameter 5 from 'LPVOID' to 'LPWSTR'
          Conversion from 'void*' to pointer to non-'void' requires an explicit cast
```
