### PR TITLE
Removed misleading usb bus number comment from udev rules template

### DIFF
--- a/udev/99-hid.rules
+++ b/udev/99-hid.rules
@@ -13,10 +13,10 @@ SUBSYSTEM=="usb", ATTRS{idVendor}=="04d8", ATTRS{idProduct}=="003f", MODE="0666"
 
 
 # If you are using the hidraw implementation, then do something like the
-# following, substituting the VID and PID with your device. Busnum 1 is USB.
+# following, substituting the VID and PID with your device.
 
 # HIDAPI/hidraw
-KERNEL=="hidraw*", ATTRS{busnum}=="1", ATTRS{idVendor}=="04d8", ATTRS{idProduct}=="003f", MODE="0666"
+KERNEL=="hidraw*", ATTRS{idVendor}=="04d8", ATTRS{idProduct}=="003f", MODE="0666"
 
 # Once done, optionally rename this file for your device, and drop it into
 # /etc/udev/rules.d and unplug and re-plug your device. This is all that is


### PR DESCRIPTION
In the hidraw section of the udev rules template, it says that "Busnum 1 is USB". The suggested rule also filters on the bus number.

That comment is misleading, because there may be multiple usb buses on a single machine. The suggested rule would only work if the device happens to be plugged into the first USB bus.

Accordingly, the suggested rule for libusb _doesn't_ filter on bus number.
