### PR TITLE
windows: wrongly enumerates devices as HIDClass if other HIDClass devices are plugged in

### DIFF
--- a/windows/hid.c
+++ b/windows/hid.c
@@ -273,7 +273,6 @@ struct hid_device_info HID_API_EXPORT * HID_API_CALL hid_enumerate(unsigned shor
 	SP_DEVICE_INTERFACE_DETAIL_DATA_A *device_interface_detail_data = NULL;
 	HDEVINFO device_info_set = INVALID_HANDLE_VALUE;
 	int device_index = 0;
-	int i;
 
 	if (hid_init() < 0)
 		return NULL;
@@ -337,12 +336,11 @@ struct hid_device_info HID_API_EXPORT * HID_API_CALL hid_enumerate(unsigned shor
 
 		/* Make sure this device is of Setup Class "HIDClass" and has a
 		   driver bound to it. */
-		for (i = 0; ; i++) {
 			char driver_name[256];
 
 			/* Populate devinfo_data. This function will return failure
 			   when there are no more interfaces left. */
-			res = SetupDiEnumDeviceInfo(device_info_set, i, &devinfo_data);
+			res = SetupDiEnumDeviceInfo(device_info_set, device_index, &devinfo_data);
 			if (!res)
 				goto cont;
 
@@ -351,14 +349,9 @@ struct hid_device_info HID_API_EXPORT * HID_API_CALL hid_enumerate(unsigned shor
 			if (!res)
 				goto cont;
 
-			if (strcmp(driver_name, "HIDClass") == 0) {
-				/* See if there's a driver bound. */
-				res = SetupDiGetDeviceRegistryPropertyA(device_info_set, &devinfo_data,
-				           SPDRP_DRIVER, NULL, (PBYTE)driver_name, sizeof(driver_name), NULL);
-				if (res)
-					break;
+			if (strcmp(driver_name, "HIDClass") != 0) {
+				goto cont;
 			}
-		}
 
 		//wprintf(L"HandleName: %s\n", device_interface_detail_data->DevicePath);
 

--- a/windows/hid.c
+++ b/windows/hid.c
@@ -353,6 +353,12 @@ struct hid_device_info HID_API_EXPORT * HID_API_CALL hid_enumerate(unsigned shor
 				goto cont;
 			}
 
+			/* See if there's a driver bound. */
+			res = SetupDiGetDeviceRegistryPropertyA(device_info_set, &devinfo_data,
+			               SPDRP_DRIVER, NULL, (PBYTE)driver_name, sizeof(driver_name), NULL);
+			if (!res)
+				goto cont;
+
 		//wprintf(L"HandleName: %s\n", device_interface_detail_data->DevicePath);
 
 		/* Open a handle to the device */


### PR DESCRIPTION
- unnecessary for loop would iterate over each device as if it were all other possible devices on the machine, tricking logic into accepting the device as "HIDClass" even if it were, for example, "Mouse" class
- see https://github.com/signal11/hidapi/issues/290 for more information
