### PR TITLE
Mac: internal hid_open_path in non exclusive mode

### DIFF
--- a/mac/hid.c
+++ b/mac/hid.c
@@ -704,7 +704,7 @@ hid_device * HID_API_EXPORT hid_open_path(const char *path)
 	}
 
 	/* Open the IOHIDDevice */
-	IOReturn ret = IOHIDDeviceOpen(dev->device_handle, kIOHIDOptionsTypeSeizeDevice);
+	IOReturn ret = IOHIDDeviceOpen(dev->device_handle, 0 /*kIOHIDOptionsTypeSeizeDevice*/);
 	if (ret == kIOReturnSuccess) {
 		char str[32];
 
@@ -991,7 +991,7 @@ void HID_API_EXPORT hid_close(hid_device *dev)
 	   been unplugged. If it's been unplugged, then calling
 	   IOHIDDeviceClose() will crash. */
 	if (!dev->disconnected) {
-		IOHIDDeviceClose(dev->device_handle, kIOHIDOptionsTypeSeizeDevice);
+		IOHIDDeviceClose(dev->device_handle, 0 /*kIOHIDOptionsTypeSeizeDevice*/);
 	}
 
 	/* Clear out the queue of received reports. */


### PR DESCRIPTION
I don't know if it's really useful to open, by default, in exclusive mode, but this patch fixed my issue.
Maybe the best thing would be to create an options "ExclusiveMode" or something like that available in the hid_open_path.