### PR TITLE
HidD_GetInputReport added to hidapi.h and hid.c in windows

### DIFF
--- a/hidapi/hidapi.h
+++ b/hidapi/hidapi.h
@@ -291,6 +291,31 @@ extern "C" {
 		*/
 		int HID_API_EXPORT HID_API_CALL hid_send_feature_report(hid_device *device, const unsigned char *data, size_t length);
 
+		/** @brief Get a input report from a HID device.
+
+		Set the first byte of @p data[] to the Report ID of the
+		input report to be read.  Make sure to allow space for this
+		extra byte in @p data[]. Upon return, the first byte will
+		still contain the Report ID, and the report data will
+		start in data[1].
+
+		@ingroup API
+		@param device A device handle returned from hid_open().
+		@param data A buffer to put the read data into, including
+		the Report ID. Set the first byte of @p data[] to the
+		Report ID of the report to be read, or set it to zero
+		if your device does not use numbered reports.
+		@param length The number of bytes to read, including an
+		extra byte for the report ID. The buffer can be longer
+		than the actual report.
+
+		@returns
+		This function returns the number of bytes read plus
+		one for the report ID (which is still in the first
+		byte), or -1 on error.
+		*/
+		int HID_API_EXPORT HID_API_CALL hid_get_report(hid_device *dev, const unsigned char *data, size_t length);
+
 		/** @brief Get a feature report from a HID device.
 
 			Set the first byte of @p data[] to the Report ID of the

--- a/windows/hid.c
+++ b/windows/hid.c
@@ -109,6 +109,7 @@ extern "C" {
 	typedef BOOLEAN (__stdcall *HidD_GetProductString_)(HANDLE handle, PVOID buffer, ULONG buffer_len);
 	typedef BOOLEAN (__stdcall *HidD_SetFeature_)(HANDLE handle, PVOID data, ULONG length);
 	typedef BOOLEAN (__stdcall *HidD_GetFeature_)(HANDLE handle, PVOID data, ULONG length);
+	typedef BOOLEAN (__stdcall *HidD_GetInputReport_)(HANDLE handle, PVOID data, ULONG length);
 	typedef BOOLEAN (__stdcall *HidD_GetIndexedString_)(HANDLE handle, ULONG string_index, PVOID buffer, ULONG buffer_len);
 	typedef BOOLEAN (__stdcall *HidD_GetPreparsedData_)(HANDLE handle, PHIDP_PREPARSED_DATA *preparsed_data);
 	typedef BOOLEAN (__stdcall *HidD_FreePreparsedData_)(PHIDP_PREPARSED_DATA preparsed_data);
@@ -121,6 +122,7 @@ extern "C" {
 	static HidD_GetProductString_ HidD_GetProductString;
 	static HidD_SetFeature_ HidD_SetFeature;
 	static HidD_GetFeature_ HidD_GetFeature;
+	static HidD_GetInputReport_ HidD_GetInputReport;
 	static HidD_GetIndexedString_ HidD_GetIndexedString;
 	static HidD_GetPreparsedData_ HidD_GetPreparsedData;
 	static HidD_FreePreparsedData_ HidD_FreePreparsedData;
@@ -211,6 +213,7 @@ static int lookup_functions()
 		RESOLVE(HidD_GetProductString);
 		RESOLVE(HidD_SetFeature);
 		RESOLVE(HidD_GetFeature);
+		RESOLVE(HidD_GetInputReport);
 		RESOLVE(HidD_GetIndexedString);
 		RESOLVE(HidD_GetPreparsedData);
 		RESOLVE(HidD_FreePreparsedData);
@@ -638,6 +641,7 @@ int HID_API_EXPORT HID_API_CALL hid_write(hid_device *dev, const unsigned char *
 	res = WriteFile(dev->device_handle, buf, length, NULL, &ol);
 	
 	if (!res) {
+		//return GetLastError();
 		if (GetLastError() != ERROR_IO_PENDING) {
 			/* WriteFile() failed. Return error. */
 			register_error(dev, "WriteFile");
@@ -751,6 +755,17 @@ int HID_API_EXPORT HID_API_CALL hid_send_feature_report(hid_device *dev, const u
 	BOOL res = HidD_SetFeature(dev->device_handle, (PVOID)data, length);
 	if (!res) {
 		register_error(dev, "HidD_SetFeature");
+		return -1;
+	}
+
+	return length;
+}
+
+int HID_API_EXPORT HID_API_CALL hid_get_report(hid_device *dev, const unsigned char *data, size_t length) {
+	
+	BOOL res = HidD_GetInputReport(dev->device_handle, (PVOID)data, length);
+	if (!res) {
+		register_error(dev, "HidD_GetInputReport");
 		return -1;
 	}
 


### PR DESCRIPTION
BOOLEAN __stdcall HidD_GetInputReport(
  _In_  HANDLE HidDeviceObject,
  _Out_ PVOID  ReportBuffer,
  _In_  ULONG  ReportBufferLength
);

Added to the windows version of the API