### PR TITLE
FreeBSD iconv fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -93,7 +93,7 @@ case $host in
 	LDFLAGS="$LDFLAGS -L/usr/local/lib"
 	LIBS="${LIBS}"
 	AC_CHECK_LIB([usb], [libusb_init], [LIBS_LIBUSB_PRIVATE="${LIBS_LIBUSB_PRIVATE} -lusb"], [hidapi_lib_error libusb])
-	AC_CHECK_LIB([iconv], [iconv_open], [LIBS_LIBUSB_PRIVATE="${LIBS_LIBUSB_PRIVATE} -liconv"], [hidapi_lib_error libiconv])
+	AC_SEARCH_LIBS([iconv_open], [iconv], [LIBS_LIBUSB_PRIVATE="${LIBS_LIBUSB_PRIVATE} ${ac_lib:+-l$ac_lib}"], [hidapi_lib_error libiconv])
 	echo libs_priv: $LIBS_LIBUSB_PRIVATE
 	;;
 *-kfreebsd*)

--- a/libusb/hid.c
+++ b/libusb/hid.c
@@ -397,7 +397,7 @@ static wchar_t *get_usb_string(libusb_device_handle *dev, uint8_t idx)
 	size_t inbytes;
 	size_t outbytes;
 	size_t res;
-#ifdef __FreeBSD__
+#if defined(__FreeBSD__) && __FreeBSD__ < 10
 	const char *inptr;
 #else
 	char *inptr;


### PR DESCRIPTION
FreeBSD uses Citrus iconv by default on all [supported releases](https://www.freebsd.org/security/). It can still use GNU libiconv but downstream limits to `WCHAR_T` (encoding) and `//TRANSLIT` extensions.