### PR TITLE
Fix a potential issue where calloc could be called with an allocation size of 0 bytes or less

### DIFF
--- a/mac/hid.c
+++ b/mac/hid.c
@@ -710,6 +710,11 @@ hid_device * HID_API_EXPORT hid_open_path(const char *path)
 
 		/* Create the buffers for receiving data */
 		dev->max_input_report_len = (CFIndex) get_max_report_length(dev->device_handle);
+		if (dev->max_input_report_len <= 0) {
+			/* Error getting kIOHIDMaxInputReportSizeKey */
+			goto return_error;
+		}
+		
 		dev->input_report_buf = calloc(dev->max_input_report_len, sizeof(uint8_t));
 
 		/* Create the Run Loop Mode for this device.


### PR DESCRIPTION
This issue has been detected by the Clang Static Analyzer