### PR TITLE
Fix a possible NULL pointer dereference which would lead to a crash

### DIFF
--- a/mac/hid.c
+++ b/mac/hid.c
@@ -798,6 +798,11 @@ static int return_data(hid_device *dev, unsigned char *data, size_t length)
 	/* Copy the data out of the linked list item (rpt) into the
 	   return buffer (data), and delete the liked list item. */
 	struct input_report *rpt = dev->input_reports;
+	if(rpt == NULL) {
+		errno = EINVAL;
+        return 0;
+	}
+	
 	size_t len = (length < rpt->len)? length: rpt->len;
 	memcpy(data, rpt->data, len);
 	dev->input_reports = rpt->next;


### PR DESCRIPTION
This issue has been found by the Clang Static Analyzer