### PR TITLE
Safety check to prevent crash on macOS when IOHIDManagerCopyDevices() returns NULL

### DIFF
--- a/mac/hid.c
+++ b/mac/hid.c
@@ -407,6 +407,8 @@ struct hid_device_info  HID_API_EXPORT *hid_enumerate(unsigned short vendor_id, 
 	/* Get a list of the Devices */
 	IOHIDManagerSetDeviceMatching(hid_mgr, NULL);
 	CFSetRef device_set = IOHIDManagerCopyDevices(hid_mgr);
+	if (device_set == NULL)
+		return NULL;
 
 	/* Convert the list into a C array so we can iterate easily. */
 	num_devices = CFSetGetCount(device_set);
@@ -1081,6 +1083,8 @@ int main(void)
 	IOHIDManagerOpen(mgr, kIOHIDOptionsTypeNone);
 
 	CFSetRef device_set = IOHIDManagerCopyDevices(mgr);
+	if (device_set == NULL)
+		return 0;
 
 	CFIndex num_devices = CFSetGetCount(device_set);
 	IOHIDDeviceRef *device_array = calloc(num_devices, sizeof(IOHIDDeviceRef));


### PR DESCRIPTION
I have seen several crashes on macOS 10.12.6 caused by the fact that IOHIDManagerCopyDevices() returned NULL. Calling CFSetGetCount() on a NULL CFSetRef causes a crash. The fix consists of checking if the CFSetRef is not NULL before using it. Here is a backtrace of a crash:

0x00007fffd04a5118 CFSetGetCount + 24
0x000000010c15147f hid_enumerate (hid.c:427)
0x000000010c151acc hid_open (hid.c:529)