### PR TITLE
Return error when can't get USB info

### DIFF
--- a/linux/hid.c
+++ b/linux/hid.c
@@ -346,6 +346,9 @@ static int get_device_string(hid_device *dev, enum device_string_id key, wchar_t
 			}
 		}
 	}
+	else {
+		ret = -1;
+	}
 
 end:
         free(serial_number_utf8);


### PR DESCRIPTION
When USB is sudenly plugged off, get_device_string call still returns 0, that means success. This commit fixes it and `get_device_string` returns -1. It is useful for checking, whether usb is still connected with some of `hid_get_*` functions.
`uname -r`: 4.13.11-1-ARCH