### PR TITLE
Fixes outstanding mac issues

### DIFF
--- a/mac/hid.c
+++ b/mac/hid.c
@@ -473,7 +473,7 @@ struct hid_device_info  HID_API_EXPORT *hid_enumerate(unsigned short vendor_id, 
 			/* Fill in the kernel_entry_id */
 			res = IORegistryEntryGetRegistryEntryID(iokit_dev, &entry_id);
 			if (res == KERN_SUCCESS) {
-				if ((cur_dev->path = calloc(16 + 3 + 1, 1)) != NULL)
+				if ((cur_dev->path = calloc(32 + 3 + 1, 1)) != NULL)
 				{
 					sprintf(cur_dev->path, "id:%llu", entry_id);
 				}

--- a/mac/hid.c
+++ b/mac/hid.c
@@ -473,8 +473,7 @@ struct hid_device_info  HID_API_EXPORT *hid_enumerate(unsigned short vendor_id, 
 			/* Fill in the kernel_entry_id */
 			res = IORegistryEntryGetRegistryEntryID(iokit_dev, &entry_id);
 			if (res == KERN_SUCCESS) {
-				if ((cur_dev->path = calloc(32 + 3 + 1, 1)) != NULL)
-				{
+				if ((cur_dev->path = calloc(32 + 3 + 1, 1)) != NULL) {
 					sprintf(cur_dev->path, "id:%llu", entry_id);
 				}
 			} else {
@@ -504,8 +503,7 @@ struct hid_device_info  HID_API_EXPORT *hid_enumerate(unsigned short vendor_id, 
 				io_registry_entry_t parentEntry = 0;
 				
 				/* Find parent entry in IORegistry */
-				if (IORegistryEntryGetParentEntry(iokit_dev, kIOServicePlane, &parentEntry) == KERN_SUCCESS)
-				{
+				if (IORegistryEntryGetParentEntry(iokit_dev, kIOServicePlane, &parentEntry) == KERN_SUCCESS) {
 					int32_t interface_number = -1;
 				
 					/* Attempt to get the USB interface number from the parent entry */
@@ -729,10 +727,8 @@ hid_device * HID_API_EXPORT hid_open_path(const char *path)
 		return NULL;
 
 	/* Check if the path represents IORegistry path or an IORegistryEntry ID */
-	if (strlen(path) > 3)
-	{
-		if (strcmp("id:", path) == 0)
-		{
+	if (strlen(path) > 3) {
+		if (strncmp("id:", path, 3) == 0) {
 			/* Get the IORegistry entry for the given ID */
 			uint64_t entry_id;
 			
@@ -743,9 +739,7 @@ hid_device * HID_API_EXPORT hid_open_path(const char *path)
 				/* No service found for ID */
 				goto return_error;
 			}
-		}
-		else
-		{
+		} else {
 			/* Get the IORegistry entry for the given path */
 			entry = IORegistryEntryFromPath(kIOMasterPortDefault, path);
 			if (entry == MACH_PORT_NULL) {
@@ -753,9 +747,7 @@ hid_device * HID_API_EXPORT hid_open_path(const char *path)
 				goto return_error;
 			}
 		}
-	}
-	else
-	{
+	} else {
 		goto return_error;
 	}
 

--- a/mac/hid.c
+++ b/mac/hid.c
@@ -188,16 +188,6 @@ static void register_error(hid_device *device, const char *op)
 }
 #endif
 
-
-static int32_t get_int_property(IOHIDDeviceRef device, CFStringRef key)
-{
-	int32_t value = 0;
-	
-	get_int_property_checked(device, key, &value);
-	
-	return (value);
-}
-
 static bool get_int_property_checked(IOHIDDeviceRef device, CFStringRef key, int32_t *outInt)
 {
 	CFTypeRef ref;
@@ -210,6 +200,15 @@ static bool get_int_property_checked(IOHIDDeviceRef device, CFStringRef key, int
 		}
 	}
 	return (false);
+}
+
+static int32_t get_int_property(IOHIDDeviceRef device, CFStringRef key)
+{
+	int32_t value = 0;
+	
+	get_int_property_checked(device, key, &value);
+	
+	return (value);
 }
 
 static unsigned short get_vendor_id(IOHIDDeviceRef device)
@@ -443,6 +442,7 @@ struct hid_device_info  HID_API_EXPORT *hid_enumerate(unsigned short vendor_id, 
 			io_object_t iokit_dev;
 			kern_return_t res;
 			uint64_t entry_id;
+			io_string_t path;
 
 			/* VID/PID match. Create the record. */
 			tmp = malloc(sizeof(struct hid_device_info));


### PR DESCRIPTION
Fixes: 
#326 - Interface number now appropriately populated. 

#301 - Some hubs created long paths that were over 512 bytes (io_string_t length). New open method by ID, rather than path.