### PR TITLE
[Mac] Set a valid interface number on hid_device_info for USB HID devices

### DIFF
--- a/hidapi/hidapi.h
+++ b/hidapi/hidapi.h
@@ -69,9 +69,13 @@ extern "C" {
 			    (Windows/Mac only).*/
 			unsigned short usage;
 			/** The USB interface which this logical device
-			    represents. Valid on both Linux implementations
-			    in all cases, and valid on the Windows implementation
-			    only if the device contains more than one interface. */
+			    represents.
+
+				* Valid on both Linux implementations in all cases
+				* Valid on the Windows implementation only if the device
+				contains more than one interface
+				* Valid on the Mac implementation if and only if the device
+				* is a USB HID device. */
 			int interface_number;
 
 			/** Pointer to the next device */


### PR DESCRIPTION
Previously the interface would never be set on Mac.

This presents a big pain because retrieving interface numbers can be the
only way to distinguish between the interfaces returned by HIDAPI.

This change makes it possible to retrieve interface number from an
hid_device_info on Mac for USB HID devices only.

It is unclear if the Mac OS IOKit library returns valid interface numbers for non-HID USB devices. Because of this, I have opted to simply skip that case - leave it initialised to `-1`.

In the future, we can easily relax this restriction if it turns out IOKit correctly returns interface number with non-HID USB devices. For now, this PR brings 90% of the value at 5% of the risk.
