### PR TITLE
add openbsd target (uses FreeBSD backend), update BSD dependency inst…

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -5,10 +5,10 @@ About
 ======
 
 HIDAPI is a multi-platform library which allows an application to interface
-with USB and Bluetooth HID-Class devices on Windows, Linux, FreeBSD, and Mac
-OS X.  HIDAPI can be either built as a shared library (.so or .dll) or
-can be embedded directly into a target application by adding a single source
-file (per platform) and a single header.
+with USB and Bluetooth HID-Class devices on Windows, Linux, FreeBSD, 
+OpenBSD, and Mac OS X.  HIDAPI can be either built as a shared library (.so
+or .dll) or can be embedded directly into a target application by adding a
+single source file (per platform) and a single header.
 
 HIDAPI has four back-ends:
 	* Windows (using hid.dll)
@@ -29,7 +29,7 @@ hidraw nodes associated with them.  Keyboards, mice, and some other devices
 which are blacklisted from having hidraw nodes will not work. Fortunately,
 for nearly all the uses of hidraw, this is not a problem.
 
-Linux/FreeBSD/libusb (libusb/hid.c):
+Linux/FreeBSD/OpenBSD/libusb (libusb/hid.c):
 This back-end uses libusb-1.0 to communicate directly to a USB device. This
 back-end will of course not work with Bluetooth devices.
 
@@ -156,16 +156,15 @@ Prerequisites:
 	git clone), you'll need Autotools:
 	    sudo apt-get install autotools-dev autoconf automake libtool
 
-	FreeBSD:
-	---------
-	On FreeBSD you will need to install GNU make, libiconv, and
-	optionally Fox-Toolkit (for the test GUI). This is done by running
-	the following:
-	    pkg_add -r gmake libiconv fox16
+	FreeBSD and OpenBSD:
+	--------------------
+	On FreeBSD and OpenBSD you will need to install GNU make, libiconv,
+	and optionally Fox-Toolkit (for the test GUI). (On OpenBSD, gmake
+	is not needed.)
 
 	If you downloaded the source directly from the git repository (using
-	git clone), you'll need Autotools:
-	    pkg_add -r autotools
+	git clone), you'll need Autotools (on FreeBSD) or autoconf and
+	automake (on OpenBSD).
 
 	Mac:
 	-----

--- a/configure.ac
+++ b/configure.ac
@@ -107,6 +107,21 @@ case $host in
 	AC_CHECK_LIB([usb], [libusb_init], [LIBS_LIBUSB_PRIVATE="${LIBS_LIBUSB_PRIVATE} -lusb"], [hidapi_lib_error libusb])
 	echo libs_priv: $LIBS_LIBUSB_PRIVATE
 	;;
+*-openbsd*)
+	AC_MSG_RESULT([ (FreeBSD back-end)])
+	AC_DEFINE(OS_FREEBSD, 1, [FreeBSD implementation])
+	AC_SUBST(OS_FREEBSD)
+	backend="libusb"
+	os="freebsd"
+	threads="pthreads"
+
+	CFLAGS="$CFLAGS -I/usr/local/include"
+	LDFLAGS="$LDFLAGS -L/usr/local/lib"
+	LIBS="${LIBS}"
+	AC_CHECK_LIB([usb-1.0], [libusb_init], [LIBS_LIBUSB_PRIVATE="${LIBS_LIBUSB_PRIVATE} -lusb-1.0"], [hidapi_lib_error libusb])
+	AC_CHECK_LIB([iconv], [libiconv_open], [LIBS_LIBUSB_PRIVATE="${LIBS_LIBUSB_PRIVATE} -liconv"], [hidapi_lib_error libiconv])
+	echo libs_priv: $LIBS_LIBUSB_PRIVATE
+	;;
 *-mingw*)
 	AC_MSG_RESULT([ (Windows back-end, using MinGW)])
 	backend="windows"


### PR DESCRIPTION
…ructions

Hi,

It builds fine on OpenBSD with the below additions to configure.ac, accounting for the different library name (`libusb-1.0`) and a different function name (`libiconv_open`).

testgui identifies the attached USB devices, however 'Send {Output,Feature} Report' and 'Get Feature Report' trigger errors.

I added mentions in the README.txt to make this a package, but this is while I'm trying to do more testing (with [OpenHMD](https://github.com/OpenHMD/OpenHMD)). Would appreciate some hints about testgui.

Here what happens with the testgui at the moment:

* Send Output Report: Could not write to device. Error reported was: (null)
* Send Feature Report: segfault and program closes. [Corefile here](https://gist.github.com/thfrwn/05a1dfc0feda7fe6a6df0a014486d6f3)
* Get Feature Report: Enter only a single report number in the text field -> Could not get feature report from device. Error reported was: (null)