### PR TITLE
Usability changes

### DIFF
--- a/windows/hid.c
+++ b/windows/hid.c
@@ -525,8 +525,8 @@ HID_API_EXPORT hid_device * HID_API_CALL hid_open(unsigned short vendor_id, unsi
 	devs = hid_enumerate(vendor_id, product_id);
 	cur_dev = devs;
 	while (cur_dev) {
-		if (cur_dev->vendor_id == vendor_id &&
-		    cur_dev->product_id == product_id) {
+		if ((cur_dev->vendor_id == vendor_id || vendor_id == 0) &&
+			(cur_dev->product_id == product_id || product_id == 0)) {
 			if (serial_number) {
 				if (wcscmp(serial_number, cur_dev->serial_number) == 0) {
 					path_to_open = cur_dev->path;
@@ -576,7 +576,7 @@ HID_API_EXPORT hid_device * HID_API_CALL hid_open_path(const char *path)
 	}
 
 	/* Set the Input Report buffer size to 64 reports. */
-	res = HidD_SetNumInputBuffers(dev->device_handle, 64);
+	res = HidD_SetNumInputBuffers(dev->device_handle, 2);
 	if (!res) {
 		register_error(dev, "HidD_SetNumInputBuffers");
 		goto err;


### PR DESCRIPTION
Vendor and product ID equals to 0 means match on any.
Reduced buffer size from 64 to 2 because 64 buffers delays the input significantly.