### PR TITLE
Remove redundant call to IOHIDManagerSetDeviceMatching

### DIFF
--- a/mac/hid.c
+++ b/mac/hid.c
@@ -405,7 +405,6 @@ struct hid_device_info  HID_API_EXPORT *hid_enumerate(unsigned short vendor_id, 
 	process_pending_events();
 
 	/* Get a list of the Devices */
-	IOHIDManagerSetDeviceMatching(hid_mgr, NULL);
 	CFSetRef device_set = IOHIDManagerCopyDevices(hid_mgr);
 
 	/* Convert the list into a C array so we can iterate easily. */


### PR DESCRIPTION
This line causes a segmentation fault when multiple threads call hid_enumerate() without calling hid_exit(). The function is already being called by init_hid_manager().