### PR TITLE
hid_close close handle immediately at win32

### DIFF
--- a/windows/hid.c
+++ b/windows/hid.c
@@ -811,6 +811,7 @@ void HID_API_EXPORT HID_API_CALL hid_close(hid_device *dev)
 	if (!dev)
 		return;
 	CancelIo(dev->device_handle);
+	SetEvent(dev->ol.hEvent);
 	free_hid_device(dev);
 }
 


### PR DESCRIPTION
In multi-thread environment, if the hid_read thread is different from the hid_close thread, the hid_read function will block the thread exiting, at the wait object operation.

This fix just set the event, after cancel io, so that, hid_read not wait anymore and exiting read 