### PR TITLE
Windows: enumerate simple devices

### DIFF
--- a/windows/hid.c
+++ b/windows/hid.c
@@ -358,7 +358,9 @@ struct hid_device_info HID_API_EXPORT * HID_API_CALL hid_enumerate(unsigned shor
 			if (!res)
 				goto cont;
 
-			if (strcmp(driver_name, "HIDClass") == 0) {
+			if ((strcmp(driver_name, "HIDClass") == 0) ||
+				(strcmp(driver_name, "Mouse") == 0) ||
+				(strcmp(driver_name, "Keyboard") == 0)) {
 				/* See if there's a driver bound. */
 				res = SetupDiGetDeviceRegistryPropertyA(device_info_set, &devinfo_data,
 				           SPDRP_DRIVER, NULL, (PBYTE)driver_name, sizeof(driver_name), NULL);


### PR DESCRIPTION
Right now, in hid_open it is checked if the connected devices have
"HIDClass" driver name. This is true for composite devices, but some
simple HID devices only have "Mouse" or "Keyboard" driver name.

With this change, one can enumerate and open these devices.

Signed-off-by: Kubicz, Filip <filip.kubicz@nordicsemi.no>