### PR TITLE
macOS: Framework location corrected.

### DIFF
--- a/mac/hid.c
+++ b/mac/hid.c
@@ -303,7 +303,7 @@ static io_service_t hidapi_IOHIDDeviceGetService(IOHIDDeviceRef device)
 	 * and the fallback method will be used.
 	 */
 	if (iokit_framework == NULL) {
-		iokit_framework = dlopen("/System/Library/IOKit.framework/IOKit", RTLD_LAZY);
+		iokit_framework = dlopen("/System/Library/Frameworks/IOKit.framework/IOKit", RTLD_LAZY);
 
 		if (iokit_framework != NULL)
 			dynamic_IOHIDDeviceGetService = dlsym(iokit_framework, "IOHIDDeviceGetService");


### PR DESCRIPTION
Hi,

according to

https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/OSX_Technology_Overview/SystemFrameworks/SystemFrameworks.html

IOKit.framework is located at "/System/Library/Frameworks/", but hidapi/mac/hid.c:hidapi_IOHIDDeviceGetService() tries to find it at "/System/Library/". That fails and at least on macOS 10.14 the fallback method seems to not working too, so that hid_enumerate() cannot determine a path. A subsequent call of hid_open() fails due to the empty path.