### PR TITLE
Enumerate fix

### DIFF
--- a/windows/hid.c
+++ b/windows/hid.c
@@ -207,33 +207,49 @@ static int lookup_functions()
 }
 #endif
 
-static HANDLE open_device(const char *path)
+static HANDLE open_device(const char *path, BOOL enumerate)
 {
 	HANDLE handle;
+	DWORD desired_access = (enumerate)? 0: (GENERIC_WRITE | GENERIC_READ);
+
+
+	if (enumerate) {
+		handle = CreateFileA(path,
+			0, /* desired access */
+			FILE_SHARE_READ|FILE_SHARE_WRITE, /*share mode*/
+			NULL,
+			OPEN_EXISTING,
+			FILE_FLAG_OVERLAPPED,//FILE_ATTRIBUTE_NORMAL,
+			0);
+
+		return handle;
+	}
 
 	/* First, try to open with sharing mode turned off. This will make it so
 	   that a HID device can only be opened once. This is to be consistent
 	   with the behavior on the other platforms. */
 	handle = CreateFileA(path,
-		GENERIC_WRITE |GENERIC_READ,
-		0, /*share mode*/
+		desired_access,
+		FILE_SHARE_READ, /*share mode*/
 		NULL,
 		OPEN_EXISTING,
 		FILE_FLAG_OVERLAPPED,//FILE_ATTRIBUTE_NORMAL,
 		0);
 
+#if 0
 	if (handle == INVALID_HANDLE_VALUE) {
 		/* Couldn't open the device. Some devices must be opened
 		   with sharing enabled (even though they are only opened once),
 		   so try it here. */
 		handle = CreateFileA(path,
-			GENERIC_WRITE |GENERIC_READ,
+			desired_access,
 			FILE_SHARE_READ|FILE_SHARE_WRITE, /*share mode*/
 			NULL,
 			OPEN_EXISTING,
 			FILE_FLAG_OVERLAPPED,//FILE_ATTRIBUTE_NORMAL,
 			0);
 	}
+#endif
 
 	return handle;
 }
@@ -339,7 +355,7 @@ struct hid_device_info HID_API_EXPORT * HID_API_CALL hid_enumerate(unsigned shor
 		//wprintf(L"HandleName: %s\n", device_interface_detail_data->DevicePath);
 
 		// Open a handle to the device
-		write_handle = open_device(device_interface_detail_data->DevicePath);
+		write_handle = open_device(device_interface_detail_data->DevicePath, TRUE);
 
 		// Check validity of write_handle.
 		if (write_handle == INVALID_HANDLE_VALUE) {
@@ -535,7 +551,7 @@ HID_API_EXPORT hid_device * HID_API_CALL hid_open_path(const char *path)
 	dev = new_hid_device();
 
 	// Open a handle to the device
-	dev->device_handle = open_device(path);
+	dev->device_handle = open_device(path, FALSE);
 
 	// Check validity of write_handle.
 	if (dev->device_handle == INVALID_HANDLE_VALUE) {

--- a/windows/hid.c
+++ b/windows/hid.c
@@ -211,45 +211,17 @@ static HANDLE open_device(const char *path, BOOL enumerate)
 {
 	HANDLE handle;
 	DWORD desired_access = (enumerate)? 0: (GENERIC_WRITE | GENERIC_READ);
+	DWORD share_mode = (enumerate)?
+	                      FILE_SHARE_READ|FILE_SHARE_WRITE:
+	                      FILE_SHARE_READ;
 
-
-	if (enumerate) {
-		handle = CreateFileA(path,
-			0, /* desired access */
-			FILE_SHARE_READ|FILE_SHARE_WRITE, /*share mode*/
-			NULL,
-			OPEN_EXISTING,
-			FILE_FLAG_OVERLAPPED,//FILE_ATTRIBUTE_NORMAL,
-			0);
-
-		return handle;
-	}
-
-	/* First, try to open with sharing mode turned off. This will make it so
-	   that a HID device can only be opened once. This is to be consistent
-	   with the behavior on the other platforms. */
 	handle = CreateFileA(path,
 		desired_access,
-		FILE_SHARE_READ, /*share mode*/
+		share_mode,
 		NULL,
 		OPEN_EXISTING,
 		FILE_FLAG_OVERLAPPED,//FILE_ATTRIBUTE_NORMAL,
 		0);
-
-#if 0
-	if (handle == INVALID_HANDLE_VALUE) {
-		/* Couldn't open the device. Some devices must be opened
-		   with sharing enabled (even though they are only opened once),
-		   so try it here. */
-		handle = CreateFileA(path,
-			desired_access,
-			FILE_SHARE_READ|FILE_SHARE_WRITE, /*share mode*/
-			NULL,
-			OPEN_EXISTING,
-			FILE_FLAG_OVERLAPPED,//FILE_ATTRIBUTE_NORMAL,
-			0);
-	}
-#endif
 
 	return handle;
 }


### PR DESCRIPTION
As USB host, am5728 evm board is connected with dlp module through USB HID V1.11.
The test function uses hidtest. in hidapi-master open source Running the test function on the ti am5728 evm board
failed to call hid_open (). Why did the call to hid_open () fail? Do you need to write dlp driver on 5728 single board?
Usb1.0 and udev libraries are currently used. Are there any restrictions on the version of the library? Thank you!
root@am57xx-evm:# ./hid_test
no device
unable to open device
Segmentation fault
root@am57xx-evm:#

The same test function can also correctly read dlp information in ubuntu, as follows:
[root@tl hid_test]# ./hid_test
Device Found
type: 0e0f 0003
path: /dev/hidraw0
serial_number:
Manufacturer: VMware
Product: VMware Virtual USB Mouse
Release: 103
Interface: 0

Device Found
type: 0451 6401
path: /dev/hidraw1
serial_number: LCR2
Manufacturer: Texas Instruments Inc.
Product: DLPC350
Release: 0
Interface: 0

Device Found
type: 0451 6401
path: /dev/hidraw2
serial_number: LCR2
Manufacturer: Texas Instruments Inc.
Product: DLPC350
Release: 0
Interface: 1

hid open dlp ok!
Manufacturer String: Texas Instruments Inc.
Product String: DLPC350
Serial Number String: (76) LCR2
Unable to read indexed string 1
Indexed String 1:
Feature Report

waiting...
waiting...
waiting...

When the dlp module is connected to the am5728 through the USB interface, the following information is printed:
root@am57xx-evm:/lib# [ 4071.898196] usb 1-1.2: new full-speed USB device number 9 using xhci-hcd
[ 4072.005095] usb 1-1.2: New USB device found, idVendor=0451, idProduct=6401
[ 4072.012029] usb 1-1.2: New USB device strings: Mfr=1, Product=2, SerialNumber=3
[ 4072.019560] usb 1-1.2: Product: DLPC350
[ 4072.023426] usb 1-1.2: Manufacturer: Texas Instruments Inc.
[ 4072.029165] usb 1-1.2: SerialNumber: LCR2
[ 4072.067017] hid-generic 0003:0451:6401.000D: hiddev0: USB HID v1.11 Device [Texas Instruments Inc. DLPC350] on usb-xhci-hcd.1.auto-1.2/input0
[ 4072.087137] input: Texas Instruments Inc. DLPC350 as /devices/platform/44000000.ocp/48880000.omap_dwc3_1/48890000.usb/xhci-hcd.1.auto/usb1/1-1/1-1.2/1-1.2:1.1/0003:0451:6401.000E/input/input9
[ 4072.158539] hid-generic 0003:0451:6401.000E: input: USB HID v1.11 Keyboard [Texas Instruments Inc. DLPC350] on usb-xhci-hcd.1.auto-1.2/input1

root@am57xx-evm:~# cat /proc/bus/input/devices
I: Bus=0019 Vendor=0001 Product=0001 Version=0100
N: Name="gpio_keys"
P: Phys=gpio-keys/input0
S: Sysfs=/devices/platform/gpio_keys/input/input1
U: Uniq=
H: Handlers=kbd event0
B: PROP=0
B: EV=100003
B: KEY=16c0 0 0 0

I: Bus=0000 Vendor=0000 Product=0000 Version=0000
N: Name="palmas_pwron"
P: Phys=palmas_pwron/input0
S: Sysfs=/devices/platform/44000000.ocp/48070000.i2c/i2c-0/0-0058/48070000.i2c:tps659038@58:tps659038_pwr_button/input/input0
U: Uniq=
H: Handlers=kbd event1
B: PROP=0
B: EV=3
B: KEY=100000 0 0 0

I: Bus=0003 Vendor=0451 Product=6401 Version=0111
N: Name="Texas Instruments Inc. DLPC350"
P: Phys=usb-xhci-hcd.1.auto-1.2/input1
S: Sysfs=/devices/platform/44000000.ocp/48880000.omap_dwc3_1/48890000.usb/xhci-hcd.1.auto/usb1/1-1/1-1.2/1-1.2:1.1/0003:0451:6401.0008/input/input6
U: Uniq=LCR2
H: Handlers=sysrq kbd mouse0 event2
B: PROP=0
B: EV=120017
B: KEY=1f0000 0 0 800000 0 e0b0ffdf 1cfffff ffffffff fffffffe
B: REL=3
B: MSC=10
B: LED=1f

There is a usbhid module on am5728 single board, but see hid code, there is no dlp drive, do you need to add dlp driver?
root@am57xx-evm:#
root@am57xx-evm:# lsmod
Module Size Used by
ipv6 317996 26
hid_generic 941 0
usbhid 27328 0
gdbserverproxy 4477 0
cryptodev 36191 1
cmemk 29155 0
xhci_plat_hcd 4469 0
xhci_hcd 102093 1 xhci_plat_hcd
usbcore 191588 3 xhci_plat_hcd,usbhid,xhci_hcd

Add the 99-hid rule file to/ etc/ udev/ rules. d, which is modified to:

HIDAPI/hidraw
KERNEL=="hidraw*", ATTRS{busnum}=="1", ATTRS{idVendor}=="04d8", ATTRS{idProduct}=="003f", MODE="0666"

There are libraries of usb1.0 and udev on the am5728 veneer, as follows:
root@am57xx-evm:/lib# ls -all

lrwxrwxrwx 1 root root 17 Dec 29 2015 libudev.so.0 -> libudev.so.0.13.1
-rwxr-xr-x 1 root root 45928 Dec 29 2015 libudev.so.0.13.1
lrwxrwxrwx 1 root root 16 Oct 8 00:00 libudev.so.1 -> libudev.so.1.6.4
-rwxr-xr-x 1 root root 108816 Oct 7 23:27 libudev.so.1.6.4
lrwxrwxrwx 1 root root 19 Dec 29 2015 libusb-0.1.so.4 -> libusb-0.1.so.4.4.4
-rwxr-xr-x 1 root root 14628 Dec 29 2015 libusb-0.1.so.4.4.4
lrwxrwxrwx 1 root root 19 Dec 29 2015 libusb-1.0.so.0 -> libusb-1.0.so.0.1.0
-rwxr-xr-x 1 root root 81652 Dec 29 2015 libusb-1.0.so.0.1.0

drwxr-xr-x 5 root root 4096 Dec 29 2015 udev
root@am57xx-evm:/lib#