### PR TITLE
Windows: enumerate a specific list of vendor/product ids

### DIFF
--- a/hidapi/hidapi.h
+++ b/hidapi/hidapi.h
@@ -131,6 +131,31 @@ extern "C" {
 		*/
 		struct hid_device_info HID_API_EXPORT * HID_API_CALL hid_enumerate(unsigned short vendor_id, unsigned short product_id);
 
+
+		/** @brief Enumerate the HID Devices.
+
+			This function returns a linked list of all the HID devices
+			attached to the system which match any of the specified 
+			vendor_ids and product_ids.
+			If @p vendor_id is set to 0 then any vendor matches.
+			If @p product_id is set to 0 then any product matches.
+			If @p vendor_id and @p product_id are both set to 0, then
+			all HID devices will be returned.
+
+			@ingroup API
+			@param vendor_ids An array of Vendor ID (VID) of the types of 
+				device to open.
+			@param product_ids An array of Product ID (PID) of the types 
+				of device to open.
+
+			@returns
+				This function returns a pointer to a linked list of type
+				struct #hid_device, containing information about the HID devices
+				attached to the system, or NULL in the case of failure. Free
+				this linked list by calling hid_free_enumeration().
+		*/
+		struct hid_device_info HID_API_EXPORT* HID_API_CALL hid_enumerate_m(unsigned short vendor_ids[], unsigned short product_ids[]);
+
 		/** @brief Free an enumeration Linked List
 
 		    This function frees a linked list created by hid_enumerate().

--- a/windows/hid.c
+++ b/windows/hid.c
@@ -499,6 +499,246 @@ cont:
 
 }
 
+struct hid_device_info HID_API_EXPORT* HID_API_CALL hid_enumerate_m(unsigned short vendor_ids[], unsigned short product_ids[])
+{
+	BOOL res;
+	struct hid_device_info* root = NULL; /* return object */
+	struct hid_device_info* cur_dev = NULL;
+
+	/* Windows objects for interacting with the driver. */
+	GUID InterfaceClassGuid = { 0x4d1e55b2, 0xf16f, 0x11cf, {0x88, 0xcb, 0x00, 0x11, 0x11, 0x00, 0x00, 0x30} };
+	SP_DEVINFO_DATA devinfo_data;
+	SP_DEVICE_INTERFACE_DATA device_interface_data;
+	SP_DEVICE_INTERFACE_DETAIL_DATA_A* device_interface_detail_data = NULL;
+	HDEVINFO device_info_set = INVALID_HANDLE_VALUE;
+	int device_index = 0;
+	int i;
+
+	if (hid_init() < 0) 
+		return NULL;
+
+	/* Initialize the Windows objects. */
+	memset(&devinfo_data, 0x0, sizeof(devinfo_data));
+	devinfo_data.cbSize = sizeof(SP_DEVINFO_DATA);
+	device_interface_data.cbSize = sizeof(SP_DEVICE_INTERFACE_DATA);
+
+	/* Get information for all the devices belonging to the HID class. */
+	device_info_set = SetupDiGetClassDevsA(&InterfaceClassGuid, NULL, NULL, DIGCF_PRESENT | DIGCF_DEVICEINTERFACE);
+
+	size_t vendor_id_length = sizeof(vendor_ids) / sizeof(vendor_ids[0]);
+
+	/* Iterate over each device in the HID class, looking for the right one. */
+
+	for (;;) {
+		HANDLE write_handle = INVALID_HANDLE_VALUE;
+		DWORD required_size = 0;
+		HIDD_ATTRIBUTES attrib;
+
+		res = SetupDiEnumDeviceInterfaces(device_info_set,
+			NULL,
+			&InterfaceClassGuid,
+			device_index,
+			&device_interface_data);
+
+		if (!res) {
+			/* A return of FALSE from this function means that
+				there are no more devices. */
+			break;
+		}
+
+		/* Call with 0-sized detail size, and let the function
+		   tell us how long the detail struct needs to be. The
+		   size is put in &required_size. */
+		res = SetupDiGetDeviceInterfaceDetailA(device_info_set,
+			&device_interface_data,
+			NULL,
+			0,
+			&required_size,
+			NULL);
+
+		/* Allocate a long enough structure for device_interface_detail_data. */
+		device_interface_detail_data = (SP_DEVICE_INTERFACE_DETAIL_DATA_A*)malloc(required_size);
+		device_interface_detail_data->cbSize = sizeof(SP_DEVICE_INTERFACE_DETAIL_DATA_A);
+
+		/* Get the detailed data for this device. The detail data gives us
+			the device path for this device, which is then passed into
+			CreateFile() to get a handle to the device. */
+		res = SetupDiGetDeviceInterfaceDetailA(device_info_set,
+			&device_interface_data,
+			device_interface_detail_data,
+			required_size,
+			NULL,
+			NULL);
+
+		if (!res) {
+			/* register_error(dev, "Unable to call SetupDiGetDeviceInterfaceDetail");
+				Continue to the next device. */
+			goto cont;
+		}
+
+		/* Make sure this device is of Setup Class "HIDClass" and has a
+		   driver bound to it. */
+		for (i = 0; ; i++) {
+			char driver_name[256];
+
+			/* Populate devinfo_data. This function will return failure
+			   when there are no more interfaces left. */
+			res = SetupDiEnumDeviceInfo(device_info_set, i, &devinfo_data);
+			if (!res) 
+				goto cont;
+
+			res = SetupDiGetDeviceRegistryPropertyA(device_info_set, &devinfo_data,
+				SPDRP_CLASS, NULL, (PBYTE)driver_name, sizeof(driver_name), NULL);
+			if (!res) 
+				goto cont;
+
+			if (strcmp(driver_name, "HIDClass") == 0) {
+				/* See if there's a driver bound. */
+				res = SetupDiGetDeviceRegistryPropertyA(device_info_set, &devinfo_data,
+					SPDRP_DRIVER, NULL, (PBYTE)driver_name, sizeof(driver_name), NULL);
+				if (res) 
+					break;
+			}
+		}
+
+		//wprintf(L"HandleName: %s\n", device_interface_detail_data->DevicePath);
+
+		/* Open a handle to the device */
+		write_handle = open_device(device_interface_detail_data->DevicePath, TRUE);
+
+		/* Check validity of write_handle. */
+		if (write_handle == INVALID_HANDLE_VALUE) {
+			/* Unable to open the device. */
+			//register_error(dev, "CreateFile");
+			goto cont_close;
+		}
+
+
+		/* Get the Vendor ID and Product ID for this device. */
+		attrib.Size = sizeof(HIDD_ATTRIBUTES);
+		HidD_GetAttributes(write_handle, &attrib);
+		//wprintf(L"Product/Vendor: %x %x\n", attrib.ProductID, attrib.VendorID);
+
+		/* Check the VIDs/PIDs to see if we should add this
+		   device to the enumeration list. */
+		unsigned int j;
+		for (j = 0; j < vendor_id_length; ++j) {
+			unsigned int vendor_id = vendor_ids[j];
+			unsigned int product_id = product_ids[j];
+			if ((vendor_id == 0x0 || attrib.VendorID == vendor_id) &&
+				(product_id == 0x0 || attrib.ProductID == product_id)) {
+
+				#define WSTR_LEN 512
+				const char* str;
+				struct hid_device_info* tmp;
+				PHIDP_PREPARSED_DATA pp_data = NULL;
+				HIDP_CAPS caps;
+				BOOLEAN res;
+				NTSTATUS nt_res;
+				wchar_t wstr[WSTR_LEN]; /* TODO: Determine Size */
+				size_t len;
+
+				/* VID/PID match. Create the record. */
+				tmp = (struct hid_device_info*) calloc(1, sizeof(struct hid_device_info));
+				if (cur_dev) {
+					cur_dev->next = tmp;
+				}
+				else {
+					root = tmp;
+				}
+				cur_dev = tmp;
+
+				/* Get the Usage Page and Usage for this device. */
+				res = HidD_GetPreparsedData(write_handle, &pp_data);
+				if (res) {
+					nt_res = HidP_GetCaps(pp_data, &caps);
+					if (nt_res == HIDP_STATUS_SUCCESS) {
+						cur_dev->usage_page = caps.UsagePage;
+						cur_dev->usage = caps.Usage;
+					}
+
+					HidD_FreePreparsedData(pp_data);
+				}
+
+				/* Fill out the record */
+				cur_dev->next = NULL;
+				str = device_interface_detail_data->DevicePath;
+				if (str) {
+					len = strlen(str);
+					cur_dev->path = (char*)calloc(len + 1, sizeof(char));
+					strncpy(cur_dev->path, str, len + 1);
+					cur_dev->path[len] = '\0';
+				}
+				else
+					cur_dev->path = NULL;
+
+				/* Serial Number */
+				res = HidD_GetSerialNumberString(write_handle, wstr, sizeof(wstr));
+				wstr[WSTR_LEN - 1] = 0x0000;
+				if (res) {
+					cur_dev->serial_number = _wcsdup(wstr);
+				}
+
+				/* Manufacturer String */
+				res = HidD_GetManufacturerString(write_handle, wstr, sizeof(wstr));
+				wstr[WSTR_LEN - 1] = 0x0000;
+				if (res) {
+					cur_dev->manufacturer_string = _wcsdup(wstr);
+				}
+
+				/* Product String */
+				res = HidD_GetProductString(write_handle, wstr, sizeof(wstr));
+				wstr[WSTR_LEN - 1] = 0x0000;
+				if (res) {
+					cur_dev->product_string = _wcsdup(wstr);
+				}
+
+				/* VID/PID */
+				cur_dev->vendor_id = attrib.VendorID;
+				cur_dev->product_id = attrib.ProductID;
+				//                printf("vendor_id: %d\n", cur_dev->vendor_id);
+				//                printf("product_id: %d\n", cur_dev->product_id);
+
+				/* Release Number */
+				cur_dev->release_number = attrib.VersionNumber;
+
+				/* Interface Number. It can sometimes be parsed out of the path
+				   on Windows if a device has multiple interfaces. See
+				   http://msdn.microsoft.com/en-us/windows/hardware/gg487473 or
+				   search for "Hardware IDs for HID Devices" at MSDN. If it's not
+				   in the path, it's set to -1. */
+				cur_dev->interface_number = -1;
+				if (cur_dev->path) {
+					char* interface_component = strstr(cur_dev->path, "&mi_");
+					if (interface_component) {
+						char* hex_str = interface_component + 4;
+						char* endptr = NULL;
+						cur_dev->interface_number = strtol(hex_str, &endptr, 16);
+						if (endptr == hex_str) {
+							/* The parsing failed. Set interface_number to -1. */
+							cur_dev->interface_number = -1;
+						}
+					}
+				}
+			}
+		}
+
+	cont_close:
+		CloseHandle(write_handle);
+	cont:
+		/* We no longer need the detail data. It can be freed */
+		free(device_interface_detail_data);
+
+		device_index++;
+
+	}
+
+	/* Close the device information handle. */
+	SetupDiDestroyDeviceInfoList(device_info_set);
+
+	return root;
+}
+
 void  HID_API_EXPORT HID_API_CALL hid_free_enumeration(struct hid_device_info *devs)
 {
 	/* TODO: Merge this with the Linux version. This function is platform-independent. */


### PR DESCRIPTION
This additional function (`enumerate_m()`) works the same as `enumerate()`, but enables a set of specific vendor ids and product ids to be specified. This avoids manual filtering of results when more than one vendor id/product id combination needs to be enumerated.