### PR TITLE
Fixes error 'AC_CONFIG_MACRO_DIR can only be used once'.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -18,7 +18,6 @@ lt_revision="0"
 lt_age="0"
 LTLDFLAGS="-version-info ${lt_current}:${lt_revision}:${lt_age}"
 
-AC_CONFIG_MACRO_DIR([m4])
 AM_INIT_AUTOMAKE([foreign -Wall -Werror])
 AC_CONFIG_MACRO_DIR([m4])
 


### PR DESCRIPTION
Fixes this error:

hidapi % ./bootstrap
+ autoreconf --install --verbose --force
autoreconf: export WARNINGS=
autoreconf: Entering directory '.'
autoreconf: configure.ac: not using Gettext
autoreconf: running: aclocal --force -I m4
configure.ac:23: error: AC_CONFIG_MACRO_DIR can only be used once
./lib/autoconf/general.m4:1970: AC_CONFIG_MACRO_DIR is expanded from...
configure.ac:23: the top level
