### PR TITLE
Update configure.ac to remove duplicate AC_CONFIG_MACRO_DIR([m4])

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -20,7 +20,6 @@ LTLDFLAGS="-version-info ${lt_current}:${lt_revision}:${lt_age}"
 
 AC_CONFIG_MACRO_DIR([m4])
 AM_INIT_AUTOMAKE([foreign -Wall -Werror])
-AC_CONFIG_MACRO_DIR([m4])
 
 m4_ifdef([AM_PROG_AR], [AM_PROG_AR])
 LT_INIT


### PR DESCRIPTION
This duplicate was fixed in a previous release, somehow got introduced again. PFA the commit for last fix for duplicate.

https://github.com/libusb/hidapi/pull/226/commits/363461494702dfd8f37943f670dd7315c4f4e364